### PR TITLE
Swerve module subclasses

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 name: Build and test robot code
-on: [push, pull_request]
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -18,15 +18,19 @@ public final class Constants {
     public static final class SwerveConstants {
         public static final int tlDrive = 1;
         public static final int tlSteer = 0;
+        public static final double tlOffsetRads = 0;
 
         public static final int trDrive = 0;
         public static final int trSteer = 0;
+        public static final double trOffsetRads = 0;
 
         public static final int blDrive = 0;
         public static final int blSteer = 0;
+        public static final double blOffsetRads = 0;
 
         public static final int brDrive = 0;
         public static final int brSteer = 0;
+        public static final double brOffsetRads = 0;
     }
 
     public static final class ShuffleboardConstants {

--- a/src/main/java/frc/robot/motorcontrol/GRTTalonFX.java
+++ b/src/main/java/frc/robot/motorcontrol/GRTTalonFX.java
@@ -15,8 +15,10 @@ public class GRTTalonFX extends WPI_TalonFX {
     public GRTTalonFX(int deviceId) {
         super(deviceId);
 
-        // Set 30.0 amp current limit
-        configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 30.0, 0, 0));
+        configFactoryDefault();
+
+        // Set 60.0 amp current limit to kick in after 0.2 seconds
+        configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 60.0, 60.0, 0.2));
     }
 
     /**

--- a/src/main/java/frc/robot/motorcontrol/GRTTalonSRX.java
+++ b/src/main/java/frc/robot/motorcontrol/GRTTalonSRX.java
@@ -15,8 +15,10 @@ public class GRTTalonSRX extends WPI_TalonSRX {
     public GRTTalonSRX(int deviceId) {
         super(deviceId);
 
-        // Set 30.0 amp current limit
-        configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 30.0, 0, 0));
+        configFactoryDefault();
+
+        // Set 60.0 amp current limit to kick in after 0.2 seconds
+        configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 60.0, 60.0, 0.2));
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/swerve/NEOTalonSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/NEOTalonSwerveModule.java
@@ -66,7 +66,6 @@ public class NEOTalonSwerveModule {
         drivePidController.setFF(driveFF);
 
         steerMotor = new GRTTalonSRX(steerPort);
-        steerMotor.configFactoryDefault();
         steerMotor.setNeutralMode(NeutralMode.Brake);
         steerMotor.setInverted(true);
 

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
@@ -53,7 +53,6 @@ public class SwerveModule {
      */
     public SwerveModule(int drivePort, int steerPort, double offsetRads) {
         driveMotor = new GRTTalonFX(drivePort);
-        driveMotor.configFactoryDefault();
         driveMotor.setNeutralMode(NeutralMode.Brake);
 
         driveMotor.configSelectedFeedbackSensor(FeedbackDevice.IntegratedSensor);

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
@@ -147,4 +147,56 @@ public class SwerveModule {
     private Rotation2d getAngle() {
         return new Rotation2d(steerEncoder.getPosition() + offsetRads);
     }
+
+    /**
+     * Utility class to construct a top left swerve module from a module's pin offset.
+     * The offset to align the pin with the front of the robot is automatically applied.
+     */
+    public static class TopLeft extends SwerveModule {
+        public TopLeft(int drivePort, int steerPort) {
+            super(drivePort, steerPort, 0.0);
+        }
+        public TopLeft(int drivePort, int steerPort, double offsetRads) {
+            super(drivePort, steerPort, offsetRads);
+        }
+    }
+
+    /**
+     * Utility class to construct a top right swerve module from a module's pin offset.
+     * The offset to align the pin with the front of the robot is automatically applied.
+     */
+    public static class TopRight extends SwerveModule {
+        public TopRight(int drivePort, int steerPort) {
+            super(drivePort, steerPort, -Math.PI / 2.0);
+        }
+        public TopRight(int drivePort, int steerPort, double offsetRads) {
+            super(drivePort, steerPort, offsetRads - Math.PI / 2.0);
+        }
+    }
+
+    /**
+     * Utility class to construct a bottom left swerve module from a module's pin offset.
+     * The offset to align the pin with the front of the robot is automatically applied.
+     */
+    public static class BottomLeft extends SwerveModule {
+        public BottomLeft(int drivePort, int steerPort) {
+            super(drivePort, steerPort, Math.PI / 2.0);
+        }
+        public BottomLeft(int drivePort, int steerPort, double offsetRads) {
+            super(drivePort, steerPort, offsetRads + Math.PI / 2.0);
+        }
+    }
+
+    /**
+     * Utility class to construct a bottom right swerve module from a module's pin offset.
+     * The offset to align the pin with the front of the robot is automatically applied.
+     */
+    public static class BottomRight extends SwerveModule {
+        public BottomRight(int drivePort, int steerPort) {
+            super(drivePort, steerPort, Math.PI);
+        }
+        public BottomRight(int drivePort, int steerPort, double offsetRads) {
+            super(drivePort, steerPort, offsetRads + Math.PI);
+        }
+    }
 }

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -33,10 +33,10 @@ public class SwerveSubsystem extends SubsystemBase {
 
     public SwerveSubsystem() {
         // Initialize swerve modules
-        topLeftModule = new SwerveModule.TopLeft(tlDrive, tlSteer);
-        topRightModule = new SwerveModule.TopRight(trDrive, trSteer);
-        bottomLeftModule = new SwerveModule.BottomLeft(blDrive, blSteer);
-        bottomRightModule = new SwerveModule.BottomRight(brDrive, brSteer);
+        topLeftModule = new SwerveModule.TopLeft(tlDrive, tlSteer, tlOffsetRads);
+        topRightModule = new SwerveModule.TopRight(trDrive, trSteer, trOffsetRads);
+        bottomLeftModule = new SwerveModule.BottomLeft(blDrive, blSteer, blOffsetRads);
+        bottomRightModule = new SwerveModule.BottomRight(brDrive, brSteer, brOffsetRads);
 
         // Initialize system kinematics with top left, top right, bottom left, and bottom right swerve
         // module positions

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -17,10 +17,10 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import static frc.robot.Constants.SwerveConstants.*;
 
 public class SwerveSubsystem extends SubsystemBase {
-    private final SwerveModule topLeftModule;
-    private final SwerveModule topRightModule;
-    private final SwerveModule bottomLeftModule;
-    private final SwerveModule bottomRightModule;
+    private final SwerveModule.TopLeft topLeftModule;
+    private final SwerveModule.TopRight topRightModule;
+    private final SwerveModule.BottomLeft bottomLeftModule;
+    private final SwerveModule.BottomRight bottomRightModule;
 
     private final SwerveDrivePoseEstimator poseEstimator;
     private final AHRS ahrs;
@@ -33,10 +33,10 @@ public class SwerveSubsystem extends SubsystemBase {
 
     public SwerveSubsystem() {
         // Initialize swerve modules
-        topLeftModule = new SwerveModule(tlDrive, tlSteer);
-        topRightModule = new SwerveModule(trDrive, trSteer);
-        bottomLeftModule = new SwerveModule(blDrive, blSteer);
-        bottomRightModule = new SwerveModule(brDrive, brSteer);
+        topLeftModule = new SwerveModule.TopLeft(tlDrive, tlSteer);
+        topRightModule = new SwerveModule.TopRight(trDrive, trSteer);
+        bottomLeftModule = new SwerveModule.BottomLeft(blDrive, blSteer);
+        bottomRightModule = new SwerveModule.BottomRight(brDrive, brSteer);
 
         // Initialize system kinematics with top left, top right, bottom left, and bottom right swerve
         // module positions


### PR DESCRIPTION
This is the 4 classes configuration described in https://discord.com/channels/964689311540838471/964689312115482656/1001301901587001364, which should allow each module to be labelled with only one number (the pin offset) with the constructor handling the additional 90 degree offset. 