### PR TITLE
Field orient using estimator value instead of gyro

### DIFF
--- a/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveSubsystem.java
@@ -96,7 +96,7 @@ public class SwerveSubsystem extends SubsystemBase {
             xPower * MAX_VEL, 
             yPower * MAX_VEL, 
             angularPower * MAX_OMEGA,
-            getGyroHeading()
+            getRobotPosition().getRotation()
         );
 
         // Calculate swerve module states from desired chassis speeds


### PR DESCRIPTION
Handles resetting the swerve field-oriented 0 degree angle by calling `resetPosition()`. We can't zero the gyro to reset the robot angle because doing so will mess up the pose estimator.

![image](https://user-images.githubusercontent.com/60120929/202869992-488b27a2-a46c-4639-bc4d-4196d94d8308.png)

Definitely need to test this to make sure we're using the pose estimator correctly, though if we properly tune it this might even be more accurate than just using the gyro.