### PR TITLE
Improved swerve module state desaturation

### DIFF
--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -109,9 +109,6 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
             bottomLeftModule.setDesiredState(new SwerveModuleState(0.0, new Rotation2d(-Math.PI / 4.0)));
             bottomRightModule.setDesiredState(new SwerveModuleState(0.0, new Rotation2d(Math.PI / 4.0)));
         } else {
-            // Desaturate speeds to ensure all velocities are under MAX_VEL after kinematics.
-            SwerveDriveKinematics.desaturateWheelSpeeds(states, MAX_VEL);
-
             topLeftModule.setDesiredState(states[0]);
             topRightModule.setDesiredState(states[1]);
             bottomLeftModule.setDesiredState(states[2]);
@@ -147,8 +144,13 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
             relative ? new Rotation2d() : getFieldHeading()
         );
 
-        // Calculate swerve module states from desired chassis speeds
+        // Calculate swerve module states from desired chassis speeds, desaturating
+        // them to ensure all velocities are under MAX_VEL after kinematics.
         this.states = kinematics.toSwerveModuleStates(speeds);
+        SwerveDriveKinematics.desaturateWheelSpeeds(
+            this.states, speeds, 
+            MAX_VEL, MAX_VEL, MAX_OMEGA
+        );
     }
 
     /**


### PR DESCRIPTION
Uses [WPILib's new `desaturateWheelSpeeds()` overload](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/math/kinematics/SwerveDriveKinematics.html#desaturateWheelSpeeds(edu.wpi.first.math.kinematics.SwerveModuleState%5B%5D,edu.wpi.first.math.kinematics.ChassisSpeeds,double,double,double)) which should account for [joystick saturation](https://github.com/wpilibsuite/allwpilib/issues/4404).

I think it's fine if we desaturate in the `setSwerveDrivePowers()` method instead of `periodic()` because any command that calls `setModuleStates()` should have desaturated those states anyways. If we *must* desaturate in periodic, it would be a bit of a hassle to grab all module states again and construct a `ChassisSpeed` object just to desaturate.