### PR TITLE
Fall back on pose estimator for field-centric heading

### DIFF
--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -224,9 +224,17 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
 
     /**
      * Zeros *only the angle* of the robot's field-relative control system.
-     * This this has *no effect* on odometry.
+     * This also resets localization to match the rotated field.
      */
     public void resetFieldAngle() {
+        Pose2d currPos = getRobotPosition();
+
+        // Reset localization angle but keep current (x, y) to preserve the origin.
+        resetPosition(new Pose2d(
+            currPos.getTranslation(),
+            new Rotation2d()
+        ));
+
         angleOffset = ahrs.getAngle();
     }
 
@@ -246,10 +254,8 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
      */
     private Rotation2d getFieldHeading() {
         // Primarily use AHRS reading, falling back on the pose estimator if the AHRS disconnects.
-        Rotation2d robotHeading = ahrs.isConnected()
-            ? getGyroHeading()
+        return ahrs.isConnected()
+            ? getGyroHeading().plus(Rotation2d.fromDegrees(angleOffset))
             : getRobotPosition().getRotation();
-
-        return robotHeading.plus(Rotation2d.fromDegrees(angleOffset));
     }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -232,18 +232,24 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
 
     /**
      * Gets the gyro angle given by the NavX AHRS, inverted to be counterclockwise positive.
-     * @return The robot heading as a Rotation2d.
+     * @return The robot's global heading as a Rotation2d.
      */
     private Rotation2d getGyroHeading() {
         return Rotation2d.fromDegrees(-ahrs.getAngle());
     }
 
     /**
-     * Gets the angle of the robot relative to the field, for field-relative control.
-     * This is equivalent to `getGyroHeading()` but with an offset applied.
-     * @return The robot heading (with offset) as a Rotation2d.
+     * Gets the angle of the robot relative to the field-relative control system.
+     * This is equivalent to the robot's global angle with an offset applied.
+     * 
+     * @return The robot's field-centric heading as a Rotation2d.
      */
     private Rotation2d getFieldHeading() {
-        return getGyroHeading().plus(Rotation2d.fromDegrees(angleOffset));
+        // Primarily use AHRS reading, falling back on the pose estimator if the AHRS disconnects.
+        Rotation2d robotHeading = ahrs.isConnected()
+            ? getGyroHeading()
+            : getRobotPosition().getRotation();
+
+        return robotHeading.plus(Rotation2d.fromDegrees(angleOffset));
     }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -213,7 +213,7 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
             currentPose
         );
 
-        angleOffset = getGyroHeading().minus(currentPose.getRotation());
+        angleOffset = gyroAngle.minus(currentPose.getRotation());
     }
 
     /**
@@ -239,7 +239,7 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
     }
 
     public void resetFieldAngle() {
-        resetFieldAngle(new Rotation2d(0));
+        resetFieldAngle(new Rotation2d());
     }
 
     /**


### PR DESCRIPTION
Currently this PR keeps the current system where resetting the field angle has no effect on localization. If resetting the field angle should also affect localization, we can either make resetting the field angle reset the localization to (0,0) or maybe try to guess the robot's new position with the angle changed (but this is probably hacky and inconsistent).