### PR TITLE
Support `MissileShellSwerveSubsystem` in `RobotContainer`

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -73,7 +73,7 @@ public class RobotContainer {
      * The container for the robot. Contains subsystems, OI devices, and commands.
      */
     public RobotContainer() {
-        driveSubsystem = new MissileShellSwerveSubsystem();
+        driveSubsystem = new SwerveSubsystem2020();
         balancerCommand = new BalancerCommand(driveSubsystem);
 
         // jetsonConnection = new JetsonConnection();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -17,6 +17,7 @@ import frc.robot.commands.BalancerCommand;
 import frc.robot.jetson.JetsonConnection;
 import frc.robot.subsystems.drivetrain.TankSubsystem;
 import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
+import frc.robot.subsystems.drivetrain.MissileShellSwerveSubsystem;
 import frc.robot.subsystems.drivetrain.SwerveSubsystem2020;
 import frc.robot.subsystems.drivetrain.BaseDrivetrain;
 
@@ -72,7 +73,7 @@ public class RobotContainer {
      * The container for the robot. Contains subsystems, OI devices, and commands.
      */
     public RobotContainer() {
-        driveSubsystem = new SwerveSubsystem2020();
+        driveSubsystem = new MissileShellSwerveSubsystem();
         balancerCommand = new BalancerCommand(driveSubsystem);
 
         // jetsonConnection = new JetsonConnection();
@@ -117,6 +118,14 @@ public class RobotContainer {
                 double turnPower = 0.75 * driveController.getRightX();
                 tankSubsystem.setDrivePowers(forwardPower, turnPower);
             }, tankSubsystem));
+        } else if (driveSubsystem instanceof MissileShellSwerveSubsystem) {
+            final MissileShellSwerveSubsystem swerveSubsystem = (MissileShellSwerveSubsystem) driveSubsystem;
+
+            swerveSubsystem.setDefaultCommand(new RunCommand(() -> {
+                double xPower = -driveController.getLeftY();
+                double yPower = -driveController.getLeftX();
+                swerveSubsystem.setDrivePowers(xPower, yPower);
+            }, swerveSubsystem));
         }
     }
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -126,15 +126,6 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
      * @param relative Whether to use relative powers instead of field-oriented control.
      */
     public void setDrivePowers(double xPower, double yPower, double angularPower, boolean relative) {
-        // If drivers are sending no input, stop all modules but hold their current angle.
-        if (xPower == 0.0 && yPower == 0.0 && angularPower == 0.0) {
-            this.states[0] = new SwerveModuleState(0.0, this.states[0].angle);
-            this.states[1] = new SwerveModuleState(0.0, this.states[1].angle);
-            this.states[2] = new SwerveModuleState(0.0, this.states[2].angle);
-            this.states[3] = new SwerveModuleState(0.0, this.states[3].angle);
-            return;
-        }
-
         // Scale [-1.0, 1.0] powers to desired velocity, turning field-relative powers
         // into robot relative chassis speeds.
         ChassisSpeeds speeds = ChassisSpeeds.fromFieldRelativeSpeeds(

--- a/src/main/java/frc/robot/subsystems/drivetrain/MissileShellSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/MissileShellSwerveSubsystem.java
@@ -20,7 +20,7 @@ public class MissileShellSwerveSubsystem extends BaseDrivetrain {
     };
 
     public MissileShellSwerveSubsystem() {
-        module = new SwerveModule(2, 1, -1.1350287199020386 + Math.PI);
+        module = new SwerveModule(2, 1, 0.352540004249);
 
         // One module at the center of the robot
         kinematics = new SwerveDriveKinematics(
@@ -36,23 +36,14 @@ public class MissileShellSwerveSubsystem extends BaseDrivetrain {
     }
 
     /**
-     * Set the field-centric swerve drive powers of the subsystem.
+     * Set the "robot"-relative swerve drive powers of the subsystem.
      * @param xPower The power [-1.0, 1.0] in the x (forward) direction.
      * @param yPower The power [-1.0, 1.0] in the y (left) direction.
-     * @param angularPower The angular (rotational) power [-1.0, 1.0].
-     * @param relative Whether to use relative powers instead of field-oriented control. This parameter has no effect.
      */
-    public void setDrivePowers(double xPower, double yPower, double angularPower, boolean relative) {
-        // If drivers are sending no input, stop all modules but hold their current angle.
-        if (xPower == 0.0 && yPower == 0.0 && angularPower == 0.0) {
-            this.states[0] = new SwerveModuleState(0.0, this.states[0].angle);
-            return;
-        }
-
-        // Scale [-1.0, 1.0] powers to desired velocity, turning field-relative powers
-        // into robot relative chassis speeds.
-        // For the missile's single-module setup, we assume that angular power is always 0 and
-        // the "robot" is always facing forward.
+    public void setDrivePowers(double xPower, double yPower) {
+        // Scale [-1.0, 1.0] powers to desired velocity, turning field-relative powers into 
+        // robot relative chassis speeds. For the missile's single-module setup, we assume that 
+        // angular power is always 0 and the "robot" is always facing forward.
         ChassisSpeeds speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
             xPower * MAX_VEL, 
             yPower * MAX_VEL, 
@@ -72,6 +63,6 @@ public class MissileShellSwerveSubsystem extends BaseDrivetrain {
      */
     @Override
     public void setDrivePowers(double xPower) {
-        setDrivePowers(xPower, 0.0, 0.0, false);
+        setDrivePowers(xPower, 0.0);
     }
 }


### PR DESCRIPTION
I also want to test removing the special if statement for idle logic on this branch. 

Alternatively to the current setup, we could consider using a common interface that the shell subsystem and `BaseSwerveSubsystem` both implement, but that seems a bit complex compared to this approach (this implementation also allows for the shell subsystem to only take two arguments for its `setDrivePowers()` method, which a common interface would not).