### PR TITLE
Make `FollowPathCommand` respect final heading

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -106,6 +106,13 @@ public class RobotContainer {
         if (driveSubsystem instanceof BaseSwerveSubsystem) {
             final BaseSwerveSubsystem swerveSubsystem = (BaseSwerveSubsystem) driveSubsystem;
 
+            autonChooser.addOption("Small straight-line curve", new FollowPathCommand(
+                swerveSubsystem, 
+                new Pose2d(), 
+                List.of(), 
+                new Pose2d(1, 0, Rotation2d.fromDegrees(90))
+            ));
+
             // S-curve auton
             autonChooser.addOption("Rotating S-curve", new FollowPathCommand(
                 swerveSubsystem, 

--- a/src/main/java/frc/robot/commands/swerve/FollowPathCommand.java
+++ b/src/main/java/frc/robot/commands/swerve/FollowPathCommand.java
@@ -17,6 +17,9 @@ import edu.wpi.first.wpilibj2.command.SwerveControllerCommand;
 import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 
 public class FollowPathCommand extends SwerveControllerCommand {
+    private final BaseSwerveSubsystem swerveSubsystem;
+    private final Rotation2d targetAngle;
+
     private static final double xP = 0.4;
     private static final double xI = 0;
     private static final double xD = 0;
@@ -28,6 +31,8 @@ public class FollowPathCommand extends SwerveControllerCommand {
     private static final double thetaP = 1.5;
     private static final double thetaI = 0;
     private static final double thetaD = 0;
+
+    private static final double ACCEPTABLE_ANGLE_ERROR_RADS = Math.toRadians(3.0);
 
     /**
      * Creates a FollowPathCommand from a given trajectory.
@@ -49,10 +54,13 @@ public class FollowPathCommand extends SwerveControllerCommand {
                     swerveSubsystem.MAX_ALPHA
                 )
             ),
-            // () -> new Rotation2d(), // TODO: this can control the angle of swerve at every timestep; hub locking?
+            // () -> new Rotation2d(),
             swerveSubsystem::setSwerveModuleStates,
             swerveSubsystem
         );
+
+        this.swerveSubsystem = swerveSubsystem;
+        this.targetAngle = trajectory.getStates().get(trajectory.getStates().size() - 1).poseMeters.getRotation();
     }
 
     /**
@@ -94,5 +102,15 @@ public class FollowPathCommand extends SwerveControllerCommand {
      */
     public FollowPathCommand(BaseSwerveSubsystem swerveSubsystem, Pose2d start, List<Translation2d> waypoints, Pose2d end) {
         this(swerveSubsystem, start, waypoints, end, false);
+    }
+
+    @Override
+    public boolean isFinished() {
+        // End the command if the trajectory has finished and we are within tolerance of our final angle.
+        // While the trajectory is finished but the robot is not at the target angle, the command will
+        // continually pass the final (stationary) trajectory state and our target angle to the holonomic
+        // controller to slowly bring the robot to the correct heading.
+        double absAngleError = Math.abs(swerveSubsystem.getRobotPosition().getRotation().minus(targetAngle).getRadians());
+        return super.isFinished() && absAngleError <= ACCEPTABLE_ANGLE_ERROR_RADS;
     }
 }


### PR DESCRIPTION
This works because sampling a trajectory past its maximum timestamp just returns the last (stationary) trajectory state, which is fed in along with the desired heading to slowly bring the robot to its target. Relevant WPILib source code snippets:
```java
// SwerveControllerCommand.execute()

  @Override
  public void execute() {
    double curTime = m_timer.get();
    var desiredState = m_trajectory.sample(curTime);

    var targetChassisSpeeds =
        m_controller.calculate(m_pose.get(), desiredState, m_desiredRotation.get());
    var targetModuleStates = m_kinematics.toSwerveModuleStates(targetChassisSpeeds);

    m_outputModuleStates.accept(targetModuleStates);
  }
```
```java
// Trajectory.sample()

  public State sample(double timeSeconds) {
    if (timeSeconds <= m_states.get(0).timeSeconds) {
      return m_states.get(0);
    }
    if (timeSeconds >= m_totalTimeSeconds) {
      return m_states.get(m_states.size() - 1);
    }
```
```java
// HolonomicDriveController.calculate()

  public ChassisSpeeds calculate(
      Pose2d currentPose,
      Pose2d trajectoryPose,
      double desiredLinearVelocityMetersPerSecond,
      Rotation2d desiredHeading) {
    // If this is the first run, then we need to reset the theta controller to the current pose's
    // heading.
    if (m_firstRun) {
      m_thetaController.reset(currentPose.getRotation().getRadians());
      m_firstRun = false;
    }

    // Calculate feedforward velocities (field-relative).
    double xFF = desiredLinearVelocityMetersPerSecond * trajectoryPose.getRotation().getCos();
    double yFF = desiredLinearVelocityMetersPerSecond * trajectoryPose.getRotation().getSin();
    double thetaFF =
        m_thetaController.calculate(
            currentPose.getRotation().getRadians(), desiredHeading.getRadians());

    m_poseError = trajectoryPose.relativeTo(currentPose);
    m_rotationError = desiredHeading.minus(currentPose.getRotation());

    if (!m_enabled) {
      return ChassisSpeeds.fromFieldRelativeSpeeds(xFF, yFF, thetaFF, currentPose.getRotation());
    }

    // Calculate feedback velocities (based on position error).
    double xFeedback = m_xController.calculate(currentPose.getX(), trajectoryPose.getX());
    double yFeedback = m_yController.calculate(currentPose.getY(), trajectoryPose.getY());

    // Return next output.
    return ChassisSpeeds.fromFieldRelativeSpeeds(
        xFF + xFeedback, yFF + yFeedback, thetaFF, currentPose.getRotation());
  }
```