### PR TITLE
Auton unit testing

### DIFF
--- a/src/main/java/frc/robot/subsystems/RollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RollerSubsystem.java
@@ -14,7 +14,7 @@ import frc.robot.motorcontrol.MotorUtil;
 
 import static frc.robot.Constants.RollerConstants.*;
 
-public class RollerSubsystem extends SubsystemBase {
+public class RollerSubsystem extends SubsystemBase implements AutoCloseable {
     private final WPI_TalonSRX leftBeak;
     private final WPI_TalonSRX rightBeak;
     private final WPI_TalonSRX openMotor;
@@ -133,6 +133,13 @@ public class RollerSubsystem extends SubsystemBase {
         else{
             System.out.println("no object");
         }
-        
+    }
+
+    @Override
+    public void close() throws Exception {
+        leftBeak.close();
+        rightBeak.close();
+        openMotor.close();
+        limitSwitch.close();
     }
 }

--- a/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
@@ -21,7 +21,7 @@ import frc.robot.motorcontrol.MotorUtil;
 
 import static frc.robot.Constants.TiltedElevatorConstants.*;
 
-public class TiltedElevatorSubsystem extends SubsystemBase {
+public class TiltedElevatorSubsystem extends SubsystemBase implements AutoCloseable {
     private final CANSparkMax extensionMotor;
     private final RelativeEncoder extensionEncoder;
     private final SparkMaxPIDController extensionPidController;
@@ -55,6 +55,7 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
 
     public boolean pieceGrabbed = false;
 
+    /*
     private final ShuffleboardTab shuffleboardTab = Shuffleboard.getTab("Tilted Elevator");
     private final GenericEntry extensionPEntry = shuffleboardTab.add("Extension P", extensionP).getEntry();
     private final GenericEntry extensionIEntry = shuffleboardTab.add("Extension I", extensionI).getEntry();
@@ -74,6 +75,7 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
     private final GenericEntry currentStateEntry = shuffleboardTab.add("Current State", state.toString()).getEntry();
 
     private final GenericEntry offsetDistEntry = shuffleboardTab.add("offset (in)", offsetDistMeters).getEntry();
+    */
 
     public enum ElevatorState {
         GROUND(0) {
@@ -148,7 +150,7 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
         // if (zeroLimitSwitch.get()) extensionEncoder.setPosition(0); 
 
         if (IS_MANUAL) {
-            manualPowerEntry.setDouble(manualPower);
+            // manualPowerEntry.setDouble(manualPower);
             extensionMotor.set(manualPower);
             return;
         }
@@ -170,9 +172,9 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
         double currentPos = extensionEncoder.getPosition();
         double currentVel = extensionEncoder.getVelocity();
 
-        currentVelEntry.setDouble(currentVel);
-        currentExtensionEntry.setDouble(Units.metersToInches(currentPos));
-        offsetDistEntry.setDouble(Units.metersToInches(offsetDistMeters));
+        // currentVelEntry.setDouble(currentVel);
+        // currentExtensionEntry.setDouble(Units.metersToInches(currentPos));
+        // offsetDistEntry.setDouble(Units.metersToInches(offsetDistMeters));
 
         // Units.inchesToMeters(targetExtensionEntry.getDouble(0));
         this.targetExtension = state.getExtension(pieceGrabbed) + offsetDistMeters;
@@ -192,7 +194,7 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
             );
         }
 
-        currentStateEntry.setString(state.toString());
+        // currentStateEntry.setString(state.toString());
     }
 
     /**
@@ -244,5 +246,29 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
         } else {
             this.manualPower = 0;
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        extensionMotor.close();
+        extensionFollow.close();
+        zeroLimitSwitch.close();
+
+        /*
+        extensionPEntry.close();
+        extensionIEntry.close();
+        extensionDEntry.close();
+        extensionFFEntry.close();
+        extensionToleranceEntry.close();
+        arbFFEntry.close();
+        manualPowerEntry.close();
+        maxVelEntry.close();
+        maxAccelEntry.close();
+        currentVelEntry.close();
+        targetExtensionEntry.close();
+        currentExtensionEntry.close();
+        currentStateEntry.close();
+        offsetDistEntry.close();
+        */
     }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveModule.java
@@ -3,7 +3,7 @@ package frc.robot.subsystems.drivetrain;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 
-public interface BaseSwerveModule {
+public interface BaseSwerveModule extends AutoCloseable {
     /**
      * Gets the current state of the module as a `SwerveModulePosition`.
      * @return The state of the module.

--- a/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/BaseSwerveSubsystem.java
@@ -22,7 +22,7 @@ import frc.robot.vision.PhotonWrapper;
  * The superclass for the current `SwerveSubsystem` and `SwerveSubsystem2020` that contains all the
  * logic for managing module states, updating odometry, and taking driver input.
  */
-public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
+public abstract class BaseSwerveSubsystem extends BaseDrivetrain implements AutoCloseable {
     private final BaseSwerveModule topLeftModule;
     private final BaseSwerveModule topRightModule;
     private final BaseSwerveModule bottomLeftModule;
@@ -44,9 +44,11 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
 
     private Rotation2d angleOffset = new Rotation2d(0);
 
+    /*
     private final ShuffleboardTab shuffleboardTab;
     private final GenericEntry xEntry, yEntry, thetaEntry;
     private final Field2d fieldWidget = new Field2d();
+    */
 
     private static final boolean SHUFFLEBOARD_ENABLE = true;
     private static final boolean VISION_ENABLE = true;
@@ -94,6 +96,7 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
             new MatBuilder<>(Nat.N3(), Nat.N1()).fill(0.1, 0.1, 0.01)
         );
 
+        /*
         shuffleboardTab = Shuffleboard.getTab("Drivetrain");
         shuffleboardTab.add("Field", fieldWidget)
             .withPosition(0, 0)
@@ -101,6 +104,7 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
         xEntry = shuffleboardTab.add("x pos (in)", 0).withPosition(0, 5).getEntry();
         yEntry = shuffleboardTab.add("y pos (in)", 0).withPosition(1, 5).getEntry();
         thetaEntry = shuffleboardTab.add("theta pos (deg)", 0).withPosition(2, 5).getEntry();
+        */
 
         lockTimer = new Timer();
     }
@@ -115,12 +119,14 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
         );
 
         // Update Shuffleboard
+        /*
         if (SHUFFLEBOARD_ENABLE) {
             xEntry.setValue(Units.metersToInches(estimate.getX()));
             yEntry.setValue(Units.metersToInches(estimate.getY()));
             thetaEntry.setValue(estimate.getRotation().getDegrees());
             fieldWidget.setRobotPose(estimate);
         }
+        */
 
         // Add vision pose estimate to pose estimator
         if (VISION_ENABLE) photonWrapper.getRobotPoses(estimate).forEach((visionPose) -> {
@@ -296,5 +302,23 @@ public abstract class BaseSwerveSubsystem extends BaseDrivetrain {
         return ahrs.isConnected()
             ? getGyroHeading().minus(angleOffset)
             : getRobotPosition().getRotation();
+    }
+
+    @Override
+    public void close() throws Exception {
+        topLeftModule.close();
+        topRightModule.close();
+        bottomLeftModule.close();
+        bottomRightModule.close();
+
+        ahrs.close();
+
+        // photonWrapper.close();
+        /*
+        xEntry.close();
+        yEntry.close();
+        thetaEntry.close();
+        fieldWidget.close();
+        */
     }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -52,10 +52,12 @@ public class SwerveModule implements BaseSwerveModule {
     private static final double steerD = 0;
     private static final double steerFF = 0;
 
+    /*
     private final ShuffleboardTab shuffleboardTab;
     private final GenericEntry 
         targetVelEntry, currentVelEntry, velErrorEntry,
         targetAngleEntry, currentAngleEntry, angleErrorEntry;
+    */
 
     /**
      * Constructs a SwerveModule from a drive and steer motor CAN ID and an angle offset.
@@ -109,6 +111,7 @@ public class SwerveModule implements BaseSwerveModule {
         steerPidController.setPositionPIDWrappingMinInput(0.0);
         steerPidController.setPositionPIDWrappingMaxInput(2 * Math.PI);
 
+        /*
         shuffleboardTab = Shuffleboard.getTab("Swerve " + drivePort + " " + steerPort);
         targetVelEntry = shuffleboardTab.add("Target velocity (mps)", 0.0)
             .withPosition(0, 0)
@@ -137,6 +140,7 @@ public class SwerveModule implements BaseSwerveModule {
             .withSize(5, 3)
             // .withWidget(BuiltInWidgets.kGraph)
             .getEntry();
+        */
 
         this.offsetRads = offsetRads;
     }
@@ -176,6 +180,7 @@ public class SwerveModule implements BaseSwerveModule {
         double targetAngle = optimized.angle.getRadians() - offsetRads;
 
         // Set shuffleboard debug info
+        /*
         targetVelEntry.setDouble(optimized.speedMetersPerSecond);
         currentVelEntry.setDouble(currentVelocity);
         velErrorEntry.setDouble(optimized.speedMetersPerSecond - currentVelocity);
@@ -183,6 +188,7 @@ public class SwerveModule implements BaseSwerveModule {
         targetAngleEntry.setDouble(Math.toDegrees(MathUtil.angleModulus(targetAngle)));
         currentAngleEntry.setDouble(currentAngle.minus(new Rotation2d(offsetRads)).getDegrees());
         angleErrorEntry.setDouble(MathUtil.angleModulus(targetAngle - currentAngle.getRadians() + offsetRads));
+        */
 
         // driveMotor.set(ControlMode.Velocity, optimized.getFirst() / (DRIVE_TICKS_TO_METERS * 10.0));
         drivePidController.setReference(optimized.speedMetersPerSecond, ControlType.kVelocity);
@@ -255,5 +261,21 @@ public class SwerveModule implements BaseSwerveModule {
         public BottomRight(int drivePort, int steerPort, double offsetRads) {
             super(drivePort, steerPort, offsetRads + Math.PI);
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        driveMotor.close();
+        steerMotor.close();
+
+        /*
+        targetVelEntry.close();
+        currentVelEntry.close();
+        velErrorEntry.close();
+
+        targetAngleEntry.close();
+        currentAngleEntry.close();
+        angleErrorEntry.close();
+        */
     }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule2020.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule2020.java
@@ -107,7 +107,8 @@ public class SwerveModule2020 implements BaseSwerveModule {
      */
     private Rotation2d getAngle() {
         return new Rotation2d(
-                steerMotor.getSelectedSensorPosition() * STEER_TICKS_TO_RADIANS + offsetRads);
+            steerMotor.getSelectedSensorPosition() * STEER_TICKS_TO_RADIANS + offsetRads
+        );
     }
 
     /**
@@ -133,5 +134,11 @@ public class SwerveModule2020 implements BaseSwerveModule {
         }
 
         return new Pair<>(targetVel, angleRads + deltaRads);
+    }
+
+    @Override
+    public void close() throws Exception {
+        driveMotor.close();
+        steerMotor.close();
     }
 }

--- a/src/test/java/AutonPathTest.java
+++ b/src/test/java/AutonPathTest.java
@@ -1,0 +1,67 @@
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.hal.HAL;
+
+import frc.robot.commands.sequences.BlueBalanceAuton;
+import frc.robot.commands.sequences.BlueBottomAuton;
+import frc.robot.commands.sequences.BlueTopAuton;
+import frc.robot.commands.sequences.RedBalanceAuton;
+import frc.robot.commands.sequences.RedBottomAuton;
+import frc.robot.commands.sequences.RedTopAuton;
+import frc.robot.commands.sequences.test.BoxAutonSequence;
+import frc.robot.commands.sequences.test.GRTAutonSequence;
+import frc.robot.commands.sequences.test.HighRotationLinePath;
+import frc.robot.commands.sequences.test.RotatingSCurveAutonSequence;
+import frc.robot.commands.sequences.test.StraightLinePath;
+import frc.robot.subsystems.RollerSubsystem;
+import frc.robot.subsystems.TiltedElevatorSubsystem;
+import frc.robot.subsystems.drivetrain.SwerveSubsystem;
+
+public class AutonPathTest {
+    private SwerveSubsystem swerveSubsystem;
+    private RollerSubsystem rollerSubsystem;
+    private TiltedElevatorSubsystem tiltedElevatorSubsystem;
+
+    @BeforeEach
+    public void setup() {
+        assert HAL.initialize(500, 0); // initialize the HAL, crash if failed
+
+        swerveSubsystem = new SwerveSubsystem(null);
+        // swerveSubsystem.getAhrs().enableLogging(false);
+        rollerSubsystem = new RollerSubsystem();
+        tiltedElevatorSubsystem = new TiltedElevatorSubsystem();
+    }
+
+    @AfterEach
+    public void shutdown() throws Exception {
+        swerveSubsystem.close();
+        rollerSubsystem.close();
+        tiltedElevatorSubsystem.close();
+    }
+
+    @Test
+    public void compileTestPaths() {
+        new StraightLinePath(swerveSubsystem);
+        new HighRotationLinePath(swerveSubsystem);
+        new RotatingSCurveAutonSequence(swerveSubsystem);
+        new BoxAutonSequence(swerveSubsystem);
+        new GRTAutonSequence(swerveSubsystem);
+    }
+
+    @Test
+    public void compileRedPaths() {
+        new RedTopAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+        new RedBalanceAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+        new RedBottomAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+    }
+
+    @Test
+    public void compileBluePaths() {
+        new BlueTopAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+        // new BlueBalanceAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+        new BlueBottomAuton(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem);
+    }
+}


### PR DESCRIPTION
Very rough implementation at the moment, as shuffleboard doesn't seem to play well with simulation mode at all. I currently just have all the shuffleboard stuff commented out, but a better solution can probably be derived in the future. 

`PhotonWrapper` also didn't seem to like being reconstructed every test, but I realized I could just pass `null` to the swerve subsystem as it wouldn't be running periodic. Perhaps a more clean solution can be found for this too.

Less major of a concern, but the AHRS / phoenix framework startup logs kinda clog up the console when running tests.

(also the `BlueBalanceAuton` path is commented out in the test because it doesn't compile; this is a known issue and will be fixed soon)