### PR TITLE
Rename mover/grabber commands to not use mech lead names

### DIFF
--- a/src/main/java/frc/robot/commands/grabber/GripperIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/grabber/GripperIntakeCommand.java
@@ -6,10 +6,10 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.GripperSubsytem;
 
 /**
- * [no use] Intakes 1 game piece with the pfft gripper mech.
+ * Intakes 1 game piece with the pfft gripper mech.
  */
-public class MatthewIntakeCommand extends InstantCommand {
-    public MatthewIntakeCommand(GripperSubsytem gripperSubsystem) {
+public class GripperIntakeCommand extends InstantCommand {
+    public GripperIntakeCommand(GripperSubsytem gripperSubsystem) {
         super(() -> {
             System.out.print("Gripper is to close");
             gripperSubsystem.setState(Value.kReverse);

--- a/src/main/java/frc/robot/commands/grabber/GripperPlaceCommand.java
+++ b/src/main/java/frc/robot/commands/grabber/GripperPlaceCommand.java
@@ -6,10 +6,10 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.GripperSubsytem;
 
 /**
- * [no use] Places 1 game piece with the pfft gripper mech.
+ * Places 1 game piece with the pfft gripper mech.
  */
-public class MatthewPlaceCommand extends InstantCommand {
-    public MatthewPlaceCommand(GripperSubsytem gripperSubsystem) {
+public class GripperPlaceCommand extends InstantCommand {
+    public GripperPlaceCommand(GripperSubsytem gripperSubsystem) {
         super(() -> {
             System.out.print("Gripper is to open");
             gripperSubsystem.setState(Value.kForward);

--- a/src/main/java/frc/robot/commands/grabber/RollerIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/grabber/RollerIntakeCommand.java
@@ -8,10 +8,10 @@ import frc.robot.subsystems.RollerSubsystem;
  * Intakes 1 game piece with the roller mech. This command runs the rollers at a set power
  * until the limit switch is triggered.
  */
-public class AidenIntakeCommand extends CommandBase {
+public class RollerIntakeCommand extends CommandBase {
     private final RollerSubsystem rollerSubsystem;
 
-    public AidenIntakeCommand(RollerSubsystem rollerSubsystem){
+    public RollerIntakeCommand(RollerSubsystem rollerSubsystem){
         this.rollerSubsystem = rollerSubsystem;
         addRequirements(rollerSubsystem);
     }

--- a/src/main/java/frc/robot/commands/grabber/RollerPlaceCommand.java
+++ b/src/main/java/frc/robot/commands/grabber/RollerPlaceCommand.java
@@ -9,12 +9,12 @@ import frc.robot.subsystems.RollerSubsystem;
  * Places 1 game piece with the roller mech. This command runs the rollers in reverse
  * at a set power for 2 seconds or until 2 seconds after the limit switch is no longer pressed.
  */
-public class AidenPlaceCommand extends CommandBase {
+public class RollerPlaceCommand extends CommandBase {
     private final RollerSubsystem rollerSubsystem;
     private final Timer runTimer;
     private final Timer endTimer;
 
-    public AidenPlaceCommand(RollerSubsystem rollerSubsystem){
+    public RollerPlaceCommand(RollerSubsystem rollerSubsystem){
         this.rollerSubsystem = rollerSubsystem;
         this.runTimer = new Timer();
         this.endTimer = new Timer();

--- a/src/main/java/frc/robot/commands/mover/PivotElevatorCommand.java
+++ b/src/main/java/frc/robot/commands/mover/PivotElevatorCommand.java
@@ -5,8 +5,8 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.PivotElevatorSubsystem;
 import frc.robot.subsystems.PivotElevatorSubsystem.MoverPosition;
 
-public class ShiraLevelCommand extends InstantCommand {
-    public ShiraLevelCommand(PivotElevatorSubsystem moverSubsystem, MoverPosition level) {
+public class PivotElevatorCommand extends InstantCommand {
+    public PivotElevatorCommand(PivotElevatorSubsystem moverSubsystem, MoverPosition level) {
         super(() -> {
             System.out.println("Mover to " + level);
             moverSubsystem.setState(level);

--- a/src/main/java/frc/robot/commands/mover/TiltedElevatorCommand.java
+++ b/src/main/java/frc/robot/commands/mover/TiltedElevatorCommand.java
@@ -5,8 +5,8 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.subsystems.TiltedElevatorSubsystem;
 import frc.robot.subsystems.TiltedElevatorSubsystem.ElevatorState;
 
-public class JulianLevelCommand extends InstantCommand {
-    public JulianLevelCommand(TiltedElevatorSubsystem tiltedElevatorSubsystem, ElevatorState level) {
+public class TiltedElevatorCommand extends InstantCommand {
+    public TiltedElevatorCommand(TiltedElevatorSubsystem tiltedElevatorSubsystem, ElevatorState level) {
         super(() -> {
             System.out.println("Mover to " + level);
             tiltedElevatorSubsystem.setState(level);

--- a/src/main/java/frc/robot/commands/sequences/BaseAutonSequence.java
+++ b/src/main/java/frc/robot/commands/sequences/BaseAutonSequence.java
@@ -7,9 +7,9 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
-import frc.robot.commands.grabber.AidenIntakeCommand;
-import frc.robot.commands.grabber.AidenPlaceCommand;
-import frc.robot.commands.mover.JulianLevelCommand;
+import frc.robot.commands.grabber.RollerIntakeCommand;
+import frc.robot.commands.grabber.RollerPlaceCommand;
+import frc.robot.commands.mover.TiltedElevatorCommand;
 import frc.robot.commands.swerve.FollowPathCommand;
 import frc.robot.positions.PiecePosition;
 import frc.robot.positions.PlacePosition;
@@ -43,8 +43,8 @@ public abstract class BaseAutonSequence extends SequentialCommandGroup {
      */
     protected Command goAndGrab(Pose2d initialPose, PiecePosition finalPose) {
         return FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), finalPose.getPose())
-            .alongWith(new JulianLevelCommand(tiltedElevatorSubsystem, ElevatorState.GROUND))
-            .alongWith(new AidenIntakeCommand(rollerSubsystem));
+            .alongWith(new TiltedElevatorCommand(tiltedElevatorSubsystem, ElevatorState.GROUND))
+            .alongWith(new RollerIntakeCommand(rollerSubsystem));
     }
 
     /**
@@ -55,7 +55,7 @@ public abstract class BaseAutonSequence extends SequentialCommandGroup {
      */
     protected Command goAndPlace(Pose2d initialPose, PlacePosition finalState) {
         return FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), finalState.getPose())
-            .alongWith(new JulianLevelCommand(tiltedElevatorSubsystem, finalState.getElevatorState())) // or .alongWith()?
-            .andThen(new AidenPlaceCommand(rollerSubsystem));
+            .alongWith(new TiltedElevatorCommand(tiltedElevatorSubsystem, finalState.getElevatorState())) // or .alongWith()?
+            .andThen(new RollerPlaceCommand(rollerSubsystem));
     }
 }

--- a/src/main/java/frc/robot/commands/sequences/BaseBottomAutonSequence.java
+++ b/src/main/java/frc/robot/commands/sequences/BaseBottomAutonSequence.java
@@ -6,7 +6,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
 
-import frc.robot.commands.mover.JulianLevelCommand;
+import frc.robot.commands.mover.TiltedElevatorCommand;
 import frc.robot.commands.swerve.FollowPathCommand;
 import frc.robot.positions.PiecePosition;
 import frc.robot.positions.PlacePosition;
@@ -54,7 +54,7 @@ public abstract class BaseBottomAutonSequence extends BaseAutonSequence {
      * @return The `SequentialCommandGroup` representing running the commands in order.
      */
     protected Command goAndGrabBottomPath(Pose2d initialPose, Pose2d midPose1, Pose2d midPose2, PiecePosition finalPose) {
-        return new JulianLevelCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
+        return new TiltedElevatorCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
             .alongWith(FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), midPose1))
             .andThen(new PrintCommand("hit MidPose1"))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose1, List.of(), midPose2))
@@ -71,7 +71,7 @@ public abstract class BaseBottomAutonSequence extends BaseAutonSequence {
      * @return The `SequentialCommandGroup` representing running the commands in order.
      */
     protected Command goAndPlaceBottomPath(Pose2d initialPose, Pose2d midPose1, Pose2d midPose2, PlacePosition finalState) {
-        return new JulianLevelCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
+        return new TiltedElevatorCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
             .alongWith(FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), midPose1))
             .andThen(new PrintCommand("hit MidPose1"))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose1, List.of(), midPose2))

--- a/src/main/java/frc/robot/commands/sequences/BaseTopAutonSequence.java
+++ b/src/main/java/frc/robot/commands/sequences/BaseTopAutonSequence.java
@@ -5,7 +5,7 @@ import java.util.List;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.Command;
 
-import frc.robot.commands.mover.JulianLevelCommand;
+import frc.robot.commands.mover.TiltedElevatorCommand;
 import frc.robot.commands.swerve.FollowPathCommand;
 import frc.robot.positions.PiecePosition;
 import frc.robot.positions.PlacePosition;
@@ -55,7 +55,7 @@ public abstract class BaseTopAutonSequence extends BaseAutonSequence {
      * @return The `SequentialCommandGroup` representing running the commands in order.
      */
     private Command goAndGrabTopPath(Pose2d initialPose, Pose2d midPose1, Pose2d midPose2, Pose2d midPose3, PiecePosition finalPose) {
-        return new JulianLevelCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
+        return new TiltedElevatorCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
             .alongWith(FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), midPose1))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose1, List.of(), midPose2))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose2, List.of(), midPose3))
@@ -72,7 +72,7 @@ public abstract class BaseTopAutonSequence extends BaseAutonSequence {
      * @return The `SequentialCommandGroup` representing running the commands in order.
      */
     private Command goAndPlaceTopPath(Pose2d initialPose, Pose2d midPose1, Pose2d midPose2, Pose2d midPose3, PlacePosition finalState) {
-        return new JulianLevelCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
+        return new TiltedElevatorCommand(tiltedElevatorSubsystem, ElevatorState.GROUND)
             .alongWith(FollowPathCommand.from(swerveSubsystem, initialPose, List.of(), midPose1))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose1, List.of(), midPose2))
             .andThen(FollowPathCommand.from(swerveSubsystem, midPose2, List.of(), midPose3))

--- a/src/main/java/frc/robot/controllers/BaseDriveController.java
+++ b/src/main/java/frc/robot/controllers/BaseDriveController.java
@@ -22,7 +22,7 @@ public abstract class BaseDriveController {
     public abstract double getRotatePower();
 
     /**
-     * Gets the whether swerve should be run in robot-relative mode.
+     * Gets whether swerve should be run in robot-relative mode.
      * @return Whether swerve should be run in robot-relative mode.
      */
     public abstract boolean getSwerveRelative();

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -42,7 +42,7 @@ public class SwerveModule implements BaseSwerveModule {
     private static final double DRIVE_ROTATIONS_TO_METERS = (1.0 / 3.0) * (13.0 / 8.0) * (1.0 / 3.0) * Math.PI * Units.inchesToMeters(4.0); // 3:1, 8:13, 3:1 gear ratios, 4.0" wheel diameter, circumference = pi * d
     private static final double STEER_VOLTS_TO_RADIANS = 2 * Math.PI / 3.3; // MA3 analog output: 3.3V -> 2pi
 
-    private static final double driveP = 0;
+    private static final double driveP = 0.35;
     private static final double driveI = 0;
     private static final double driveD = 0;
     private static final double driveFF = 0.176697057706;


### PR DESCRIPTION
Also brings an uncommitted change to the swerve module's drive PID to `main`.