### PR TITLE
Poll for PID updates with `.readQueue()`

### DIFF
--- a/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.util.MotorUtil;
+import frc.robot.util.ShuffleboardUtil;
 
 import static frc.robot.Constants.MoverConstants.*;
 
@@ -28,15 +29,15 @@ public class PivotElevatorSubsystem extends SubsystemBase{
     private RelativeEncoder extensionEncoder;
     private SparkMaxPIDController extensionPidController;
 
-    private double rotationP = 0.125;
-    private double rotationI = 0;
-    private double rotationD = 0;
-    private final double ROTATION_ROT_TO_RAD = ROTATION_GEAR_RATIO * 2 * Math.PI;
+    private static final double rotationP = 0.125;
+    private static final double rotationI = 0;
+    private static final double rotationD = 0;
+    private static final double ROTATION_ROT_TO_RAD = ROTATION_GEAR_RATIO * 2 * Math.PI;
 
-    private double extensionP = 0.125;
-    private double extensionI = 0;
-    private double extensionD = 0;
-    private final double EXTENSION_ROT_TO_M = Units.inchesToMeters(0.5615); 
+    private static final double extensionP = 0.125;
+    private static final double extensionI = 0;
+    private static final double extensionD = 0;
+    private static final double EXTENSION_ROT_TO_M = Units.inchesToMeters(0.5615); 
 
     private final boolean RESET_OFFSET_ON_STAGE_SWITCH = true;
     private double angleOffset = 0; //radians
@@ -59,10 +60,6 @@ public class PivotElevatorSubsystem extends SubsystemBase{
     private final GenericEntry extensionPEntry = shuffleboardTab.add("Extension P", extensionP).getEntry();
     private final GenericEntry extensionIEntry = shuffleboardTab.add("Extension I", extensionI).getEntry();
     private final GenericEntry extensionDEntry = shuffleboardTab.add("Extension D", extensionD).getEntry();
-
-    public enum GamePiece {
-        CONE, CUBE;
-    }
 
     public enum MoverPosition {
         VERTICAL(0, 0),
@@ -145,7 +142,7 @@ public class PivotElevatorSubsystem extends SubsystemBase{
 
     @Override
     public void periodic(){
-        if(!TESTING){
+        if (!TESTING) {
             goTo(currentState.angle + angleOffset, currentState.extension + extensionOffset);
         }
 
@@ -153,33 +150,14 @@ public class PivotElevatorSubsystem extends SubsystemBase{
         currentExtensionEntry.setDouble(Units.metersToInches(extensionEncoder.getPosition()));
         targetAngleEntry.setDouble(Units.radiansToDegrees(currentState.angle + angleOffset));
         targetExtensionEntry.setDouble(Units.metersToInches(currentState.extension + extensionOffset));
-        
-        double rotp = rotationPEntry.getDouble(rotationP);
-        double roti = rotationIEntry.getDouble(rotationI);
-        double rotd = rotationDEntry.getDouble(rotationD);
 
-        double extp = extensionPEntry.getDouble(extensionP);
-        double exti = extensionIEntry.getDouble(extensionI);
-        double extd = extensionDEntry.getDouble(extensionD);
+        ShuffleboardUtil.pollShuffleboardP(rotationPEntry, rotationPidController);
+        ShuffleboardUtil.pollShuffleboardI(rotationIEntry, rotationPidController);
+        ShuffleboardUtil.pollShuffleboardD(rotationDEntry, rotationPidController);
 
-        if(rotp != rotationP){
-            rotationP = rotp;
-        }
-        if(roti != rotationI){
-            rotationI = roti;
-        }
-        if(rotd != rotationD){
-            rotationD = rotd;
-        }
-        if(extp != extensionP){
-            extensionP = extp;
-        }
-        if(exti != extensionI){
-            extensionI = exti;
-        }
-        if(extd != extensionD){
-            extensionD = extd;
-        }
+        ShuffleboardUtil.pollShuffleboardP(extensionPEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardI(extensionIEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardD(extensionDEntry, extensionPidController);
     }
 
     private void goTo(double angle, double extension){
@@ -210,8 +188,8 @@ public class PivotElevatorSubsystem extends SubsystemBase{
             setOffsetPowers(xPower, yPower);
         }
     }
+
     public void setOffsetPowers(double xPower, double yPower){
-        
         angleOffset += xPower * ANGLE_OFFSET_SPEED;
         extensionOffset += yPower * EXTENSION_OFFSET_SPEED;
     }

--- a/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
@@ -151,13 +151,13 @@ public class PivotElevatorSubsystem extends SubsystemBase{
         targetAngleEntry.setDouble(Units.radiansToDegrees(currentState.angle + angleOffset));
         targetExtensionEntry.setDouble(Units.metersToInches(currentState.extension + extensionOffset));
 
-        ShuffleboardUtil.pollShuffleboardP(rotationPEntry, rotationPidController);
-        ShuffleboardUtil.pollShuffleboardI(rotationIEntry, rotationPidController);
-        ShuffleboardUtil.pollShuffleboardD(rotationDEntry, rotationPidController);
+        ShuffleboardUtil.pollShuffleboardDouble(rotationPEntry, rotationPidController::setP);
+        ShuffleboardUtil.pollShuffleboardDouble(rotationIEntry, rotationPidController::setI);
+        ShuffleboardUtil.pollShuffleboardDouble(rotationDEntry, rotationPidController::setD);
 
-        ShuffleboardUtil.pollShuffleboardP(extensionPEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardI(extensionIEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardD(extensionDEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionPEntry, extensionPidController::setP);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionIEntry, extensionPidController::setI);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionDEntry, extensionPidController::setD);
     }
 
     private void goTo(double angle, double extension){

--- a/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PivotElevatorSubsystem.java
@@ -13,7 +13,7 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 import static frc.robot.Constants.MoverConstants.*;
 

--- a/src/main/java/frc/robot/subsystems/RollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RollerSubsystem.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 import static frc.robot.Constants.RollerConstants.*;
 

--- a/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
@@ -162,13 +162,13 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
             return;
         }
 
-        ShuffleboardUtil.pollShuffleboardP(extensionPEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardI(extensionIEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardD(extensionDEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardFF(extensionFFEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardMaxVel(maxVelEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardMaxAccel(maxAccelEntry, extensionPidController);
-        ShuffleboardUtil.pollShuffleboardSmartMotionTolerance(extensionToleranceEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionPEntry, extensionPidController::setP);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionIEntry, extensionPidController::setI);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionDEntry, extensionPidController::setD);
+        ShuffleboardUtil.pollShuffleboardDouble(extensionFFEntry, extensionPidController::setFF);
+        ShuffleboardUtil.pollShuffleboardDouble(maxVelEntry, (value) -> extensionPidController.setSmartMotionMaxVelocity(value, 0));
+        ShuffleboardUtil.pollShuffleboardDouble(maxAccelEntry, (value) -> extensionPidController.setSmartMotionMaxAccel(value, 0));
+        ShuffleboardUtil.pollShuffleboardDouble(extensionToleranceEntry, (value) -> extensionPidController.setSmartMotionAllowedClosedLoopError(value, 0));
         arbFeedforward = arbFFEntry.getDouble(arbFeedforward);
 
         // System.out.println(extensionEncoder.getPosition());

--- a/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TiltedElevatorSubsystem.java
@@ -17,7 +17,8 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
+import frc.robot.util.ShuffleboardUtil;
 
 import static frc.robot.Constants.TiltedElevatorConstants.*;
 
@@ -35,44 +36,31 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
     private static final double EXTENSION_ROTATIONS_TO_METERS = EXTENSION_GEAR_RATIO * EXTENSION_CIRCUMFERENCE * 2.0 * (15.0 / 13.4);
     private static final float EXTENSION_LIMIT = 26.0f;
 
-    private double extensionP = 0.25; //.4 // 4.9;
-    private double extensionI = 0;
-    private double extensionD = 0.9; //.2
-    private double extensionFF = 0.3; //0.1
-    private double extensionTolerance = 0.003;
+    private static final double extensionP = 0.25; //.4 // 4.9;
+    private static final double extensionI = 0;
+    private static final double extensionD = 0.9; //.2
+    private static final double extensionFF = 0.3; //0.1
+    private static final double maxVel = 1.1; // m/s
+    private static final double maxAccel = 1.8; // 0.6 // m/s^2
+    private static final double extensionTolerance = 0.003;
     private double arbFeedforward = 0.02;
 
-    private double maxVel = 1.1; // m/s
-    private double maxAccel = 1.8; // 0.6 // m/s^2
-
     private ElevatorState state = ElevatorState.GROUND;
+
+    private static final boolean IS_MANUAL = false;
     private double manualPower = 0;
-    private double offsetDistMeters = 0;
 
     private static final double OFFSET_FACTOR = 0.01; // The factor to multiply driver input by when changing the offset.
-    private static final boolean IS_MANUAL = false;
+    private double offsetDistMeters = 0;
 
     public boolean pieceGrabbed = false;
 
-    private final ShuffleboardTab shuffleboardTab = Shuffleboard.getTab("Tilted Elevator");
-    private final GenericEntry extensionPEntry = shuffleboardTab.add("Extension P", extensionP).getEntry();
-    private final GenericEntry extensionIEntry = shuffleboardTab.add("Extension I", extensionI).getEntry();
-    private final GenericEntry extensionDEntry = shuffleboardTab.add("Extension D", extensionD).getEntry();
-    private final GenericEntry extensionFFEntry = shuffleboardTab.add("Extension FF", extensionFF).getEntry();
-    private final GenericEntry extensionToleranceEntry = shuffleboardTab.add("Extension Tolerance", extensionTolerance).getEntry();
-    private final GenericEntry arbFFEntry = shuffleboardTab.add("Arb FF", arbFeedforward).getEntry();
-
-    private final GenericEntry manualPowerEntry = shuffleboardTab.add("Manual Power", manualPower).getEntry();
-
-    private final GenericEntry maxVelEntry = shuffleboardTab.add("Max Vel", maxVel).getEntry();
-    private final GenericEntry maxAccelEntry = shuffleboardTab.add("Max Accel", maxAccel).getEntry();
-    private final GenericEntry currentVelEntry = shuffleboardTab.add("Current Vel (mps)", 0.0).getEntry();
-
-    private final GenericEntry targetExtensionEntry = shuffleboardTab.add("Target Ext (in)", 0.0).getEntry();
-    private final GenericEntry currentExtensionEntry = shuffleboardTab.add("Current Ext (in)", 0.0).getEntry();
-    private final GenericEntry currentStateEntry = shuffleboardTab.add("Current State", state.toString()).getEntry();
-
-    private final GenericEntry offsetDistEntry = shuffleboardTab.add("offset (in)", offsetDistMeters).getEntry();
+    private final ShuffleboardTab shuffleboardTab;
+    private final GenericEntry 
+        extensionPEntry, extensionIEntry, extensionDEntry, extensionFFEntry,
+        maxVelEntry, maxAccelEntry, extensionToleranceEntry, arbFFEntry;
+    private final GenericEntry manualPowerEntry, targetExtensionEntry;
+    private final GenericEntry currentExtensionEntry, currentVelEntry, currentStateEntry, offsetDistEntry;
 
     public enum ElevatorState {
         GROUND(0) {
@@ -141,43 +129,53 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
             sparkMax.follow(extensionMotor);
             sparkMax.setIdleMode(IdleMode.kBrake);
         });
+
+        // TODO: positions
+        shuffleboardTab = Shuffleboard.getTab("Tilted Elevator");
+
+        extensionPEntry = shuffleboardTab.add("Extension P", extensionP).withPosition(0, 0).getEntry();
+        extensionIEntry = shuffleboardTab.add("Extension I", extensionI).getEntry();
+        extensionDEntry = shuffleboardTab.add("Extension D", extensionD).getEntry();
+        extensionFFEntry = shuffleboardTab.add("Extension FF", extensionFF).getEntry();
+        maxVelEntry = shuffleboardTab.add("Max vel", maxVel).getEntry();
+        maxAccelEntry = shuffleboardTab.add("Max accel", maxAccel).getEntry();
+        extensionToleranceEntry = shuffleboardTab.add("Extension tolerance", extensionTolerance).getEntry();
+        arbFFEntry = shuffleboardTab.add("Arb FF", arbFeedforward).getEntry();
+
+        manualPowerEntry = shuffleboardTab.add("Manual Power", manualPower).getEntry();
+        targetExtensionEntry = shuffleboardTab.add("Target Ext (in)", 0.0).getEntry();
+
+        currentStateEntry = shuffleboardTab.add("Current state", state.toString()).getEntry();
+        currentExtensionEntry = shuffleboardTab.add("Current Ext (in)", 0.0).getEntry();
+        currentVelEntry = shuffleboardTab.add("Current Vel (mps)", 0.0).getEntry();
+        offsetDistEntry = shuffleboardTab.add("Offset (in)", offsetDistMeters).getEntry();
     }
 
     @Override
     public void periodic() {
         // if (zeroLimitSwitch.get()) extensionEncoder.setPosition(0); 
 
+        // If we're in manual power mode, use percent out power supplied by driver joystick.
         if (IS_MANUAL) {
             manualPowerEntry.setDouble(manualPower);
             extensionMotor.set(manualPower);
             return;
         }
 
-        // Otherwise, use PID
-        /*
-        extensionPidController.setP(extensionPEntry.getDouble(extensionP));
-        extensionPidController.setI(extensionIEntry.getDouble(extensionI));
-        extensionPidController.setD(extensionDEntry.getDouble(extensionD));
-        extensionPidController.setFF(extensionFFEntry.getDouble(extensionFF));
-        extensionPidController.setSmartMotionMaxVelocity(maxVelEntry.getDouble(maxVel), 0);
-        extensionPidController.setSmartMotionMaxAccel(maxAccelEntry.getDouble(maxAccel), 0);
-        extensionPidController.setSmartMotionAllowedClosedLoopError(extensionToleranceEntry.getDouble(extensionTolerance), 0);
+        ShuffleboardUtil.pollShuffleboardP(extensionPEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardI(extensionIEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardD(extensionDEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardFF(extensionFFEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardMaxVel(maxVelEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardMaxAccel(maxAccelEntry, extensionPidController);
+        ShuffleboardUtil.pollShuffleboardSmartMotionTolerance(extensionToleranceEntry, extensionPidController);
         arbFeedforward = arbFFEntry.getDouble(arbFeedforward);
-        */
 
         // System.out.println(extensionEncoder.getPosition());
 
         double currentPos = extensionEncoder.getPosition();
         double currentVel = extensionEncoder.getVelocity();
-
-        currentVelEntry.setDouble(currentVel);
-        currentExtensionEntry.setDouble(Units.metersToInches(currentPos));
-        offsetDistEntry.setDouble(Units.metersToInches(offsetDistMeters));
-
-        // Units.inchesToMeters(targetExtensionEntry.getDouble(0));
         double targetExtension = state.getExtension(pieceGrabbed) + offsetDistMeters;
-
-        targetExtensionEntry.setDouble(targetExtension);
 
         // If we're trying to get to 0, set the motor to 0 power so the carriage drops with gravity
         // and hits the hard stop / limit switch.
@@ -194,7 +192,11 @@ public class TiltedElevatorSubsystem extends SubsystemBase {
             );
         }
 
+        currentExtensionEntry.setDouble(Units.metersToInches(currentPos));
+        currentVelEntry.setDouble(currentVel);
         currentStateEntry.setString(state.toString());
+        targetExtensionEntry.setDouble(targetExtension);
+        offsetDistEntry.setDouble(Units.metersToInches(offsetDistMeters));
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/drivetrain/MissileShellSwerveSweeperSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/MissileShellSwerveSweeperSubsystem.java
@@ -10,7 +10,7 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 
 import frc.robot.Constants;
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 public class MissileShellSwerveSweeperSubsystem extends BaseDrivetrain {
     private final CANSparkMax steerMotor;
@@ -25,7 +25,7 @@ public class MissileShellSwerveSweeperSubsystem extends BaseDrivetrain {
     private final GenericEntry currentVoltsEntry, maxVoltsEntry, minVoltsEntry;
 
     public MissileShellSwerveSweeperSubsystem() {
-        steerMotor = MotorUtil.createSparkMax(STEER_PORT, (CANSparkMax sparkMax) -> {
+        steerMotor = MotorUtil.createSparkMax(STEER_PORT, (sparkMax) -> {
             sparkMax.setIdleMode(IdleMode.kBrake);
 
             steerAbsoluteEncoder = sparkMax.getAnalog(SparkMaxAnalogSensor.Mode.kAbsolute);

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule.java
@@ -22,7 +22,7 @@ import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 /**
  * A swerve module with a Falcon drive motor and a NEO steer motor.

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule2020.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveModule2020.java
@@ -16,7 +16,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 /**
  * A swerve module with a NEO drive motor and a BAG steer motor, for running

--- a/src/main/java/frc/robot/subsystems/drivetrain/TankSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/TankSubsystem.java
@@ -4,7 +4,7 @@ import com.ctre.phoenix.motorcontrol.InvertType;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
-import frc.robot.motorcontrol.MotorUtil;
+import frc.robot.util.MotorUtil;
 
 import static frc.robot.Constants.TankConstants.*;
 

--- a/src/main/java/frc/robot/util/MotorUtil.java
+++ b/src/main/java/frc/robot/util/MotorUtil.java
@@ -1,4 +1,4 @@
-package frc.robot.motorcontrol;
+package frc.robot.util;
 
 import java.util.function.Consumer;
 

--- a/src/main/java/frc/robot/util/ShuffleboardUtil.java
+++ b/src/main/java/frc/robot/util/ShuffleboardUtil.java
@@ -3,6 +3,7 @@ package frc.robot.util;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.revrobotics.SparkMaxPIDController;
 
 import edu.wpi.first.networktables.GenericEntry;
@@ -19,12 +20,30 @@ public class ShuffleboardUtil {
     }
 
     /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's P gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardP(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.config_kP(0, value.getDouble()));
+    }
+
+    /**
      * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's I gain if it is found.
      * @param entry The shuffleboard entry to poll.
      * @param pidController The PID controller to update.
      */
     public static void pollShuffleboardI(GenericEntry entry, SparkMaxPIDController pidController) {
         pollShuffleboardValue(entry, (value) -> pidController.setI(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's P gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardI(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.config_kI(0, value.getDouble()));
     }
 
     /**
@@ -37,12 +56,30 @@ public class ShuffleboardUtil {
     }
 
     /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's D gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardD(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.config_kD(0, value.getDouble()));
+    }
+
+    /**
      * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's FF gain if it is found.
      * @param entry The shuffleboard entry to poll.
      * @param pidController The PID controller to update.
      */
     public static void pollShuffleboardFF(GenericEntry entry, SparkMaxPIDController pidController) {
         pollShuffleboardValue(entry, (value) -> pidController.setFF(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's FF gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardFF(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.config_kF(0, value.getDouble()));
     }
 
     /**
@@ -57,6 +94,17 @@ public class ShuffleboardUtil {
     }
 
     /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's MotionMagic
+     * cruise (max) velocity if it is found.
+     * 
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardMaxVel(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.configMotionCruiseVelocity(value.getDouble()));
+    }
+
+    /**
      * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
      * Smart Motion max acceleration if it is found.
      * 
@@ -65,6 +113,17 @@ public class ShuffleboardUtil {
      */
     public static void pollShuffleboardMaxAccel(GenericEntry entry, SparkMaxPIDController pidController) {
         pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionMaxAccel(value.getDouble(), 0));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's MotionMagic
+     * max acceleration if it is found.
+     * 
+     * @param entry The shuffleboard entry to poll.
+     * @param talon The TalonSRX to update.
+     */
+    public static void pollShuffleboardMaxAccel(GenericEntry entry, WPI_TalonSRX talon) {
+        pollShuffleboardValue(entry, (value) -> talon.configMotionAcceleration(value.getDouble()));
     }
 
     /**

--- a/src/main/java/frc/robot/util/ShuffleboardUtil.java
+++ b/src/main/java/frc/robot/util/ShuffleboardUtil.java
@@ -1,12 +1,39 @@
 package frc.robot.util;
 
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.function.Consumer;
 
 import edu.wpi.first.networktables.GenericEntry;
+import edu.wpi.first.networktables.NetworkTableEvent;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.NetworkTableValue;
 
 public class ShuffleboardUtil {
+    private static final NetworkTableInstance networkTableInstance = NetworkTableInstance.getDefault();
+
+    /**
+     * Sets up a listener on a Shuffleboard entry for a `double` change, calling the provided callback on new values.
+     * @param entry The shuffleboard entry to poll.
+     * @param callback The callback to run on a new `double` value.
+     */
+    public static void addDoubleListener(GenericEntry entry, Consumer<Double> callback) {
+        addValueListener(entry, (value) -> callback.accept(value.getDouble()));
+    }
+
+    /**
+     * Sets up a listener on a Shuffleboard entry for a value change, calling the provided callback on new values.
+     * @param entry The shuffleboard entry to poll.
+     * @param callback The callback to run on a new `NetworkTableValue` value.
+     */
+    public static void addValueListener(GenericEntry entry, Consumer<NetworkTableValue> callback) {
+        networkTableInstance.addListener(
+            entry, 
+            EnumSet.of(NetworkTableEvent.Kind.kImmediate, NetworkTableEvent.Kind.kValueAll), 
+            (event) -> callback.accept(event.valueData.value)
+        );
+    }
+
     /**
      * Polls a Shuffleboard entry for a `double` change, calling the provided callback if it is found.
      * @param entry The shuffleboard entry to poll.
@@ -34,6 +61,6 @@ public class ShuffleboardUtil {
     private static Optional<NetworkTableValue> getLatestUpdate(GenericEntry entry) {
         NetworkTableValue[] updates = entry.readQueue();
         if (updates.length == 0) return Optional.empty();
-        return Optional.of(updates[updates.length - 1]); // TODO: make sure array is last-to-first
+        return Optional.of(updates[updates.length - 1]);
     }
 }

--- a/src/main/java/frc/robot/util/ShuffleboardUtil.java
+++ b/src/main/java/frc/robot/util/ShuffleboardUtil.java
@@ -3,146 +3,25 @@ package frc.robot.util;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
-import com.revrobotics.SparkMaxPIDController;
-
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.networktables.NetworkTableValue;
 
 public class ShuffleboardUtil {
     /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's P gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardP(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setP(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's P gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardP(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.config_kP(0, value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's I gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardI(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setI(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's P gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardI(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.config_kI(0, value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's D gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardD(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setD(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's D gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardD(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.config_kD(0, value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's FF gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardFF(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setFF(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's FF gain if it is found.
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardFF(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.config_kF(0, value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
-     * Smart Motion max velocity if it is found.
-     * 
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardMaxVel(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionMaxVelocity(value.getDouble(), 0));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's MotionMagic
-     * cruise (max) velocity if it is found.
-     * 
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardMaxVel(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.configMotionCruiseVelocity(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
-     * Smart Motion max acceleration if it is found.
-     * 
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardMaxAccel(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionMaxAccel(value.getDouble(), 0));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided TalonSRX's MotionMagic
-     * max acceleration if it is found.
-     * 
-     * @param entry The shuffleboard entry to poll.
-     * @param talon The TalonSRX to update.
-     */
-    public static void pollShuffleboardMaxAccel(GenericEntry entry, WPI_TalonSRX talon) {
-        pollShuffleboardValue(entry, (value) -> talon.configMotionAcceleration(value.getDouble()));
-    }
-
-    /**
-     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
-     * SmartMotion allowed closed loop error if it is found.
-     * 
-     * @param entry The shuffleboard entry to poll.
-     * @param pidController The PID controller to update.
-     */
-    public static void pollShuffleboardSmartMotionTolerance(GenericEntry entry, SparkMaxPIDController pidController) {
-        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionAllowedClosedLoopError(value.getDouble(), 0));
-    }
-
-    /**
      * Polls a Shuffleboard entry for a `double` change, calling the provided callback if it is found.
      * @param entry The shuffleboard entry to poll.
      * @param callback The callback to run on a new `double` value.
      */
-    private static void pollShuffleboardValue(GenericEntry entry, Consumer<NetworkTableValue> callback) {
+    public static void pollShuffleboardDouble(GenericEntry entry, Consumer<Double> callback) {
+        pollShuffleboardValue(entry, (value) -> callback.accept(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a value change, calling the provided callback if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param callback The callback to run on a new `NetworkTableValue` value.
+     */
+    public static void pollShuffleboardValue(GenericEntry entry, Consumer<NetworkTableValue> callback) {
         Optional<NetworkTableValue> update = getLatestUpdate(entry);
         update.ifPresent(callback);
     }

--- a/src/main/java/frc/robot/util/ShuffleboardUtil.java
+++ b/src/main/java/frc/robot/util/ShuffleboardUtil.java
@@ -1,0 +1,101 @@
+package frc.robot.util;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.revrobotics.SparkMaxPIDController;
+
+import edu.wpi.first.networktables.GenericEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
+
+public class ShuffleboardUtil {
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's P gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardP(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setP(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's I gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardI(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setI(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's D gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardD(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setD(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's FF gain if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardFF(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setFF(value.getDouble()));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
+     * Smart Motion max velocity if it is found.
+     * 
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardMaxVel(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionMaxVelocity(value.getDouble(), 0));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
+     * Smart Motion max acceleration if it is found.
+     * 
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardMaxAccel(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionMaxAccel(value.getDouble(), 0));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, updating the provided SparkMax PID controller's
+     * SmartMotion allowed closed loop error if it is found.
+     * 
+     * @param entry The shuffleboard entry to poll.
+     * @param pidController The PID controller to update.
+     */
+    public static void pollShuffleboardSmartMotionTolerance(GenericEntry entry, SparkMaxPIDController pidController) {
+        pollShuffleboardValue(entry, (value) -> pidController.setSmartMotionAllowedClosedLoopError(value.getDouble(), 0));
+    }
+
+    /**
+     * Polls a Shuffleboard entry for a `double` change, calling the provided callback if it is found.
+     * @param entry The shuffleboard entry to poll.
+     * @param callback The callback to run on a new `double` value.
+     */
+    private static void pollShuffleboardValue(GenericEntry entry, Consumer<NetworkTableValue> callback) {
+        Optional<NetworkTableValue> update = getLatestUpdate(entry);
+        update.ifPresent(callback);
+    }
+
+    /**
+     * Reads a Shuffleboard entry's queue and returns the latest updated value, if it exists.
+     * @param entry The entry to query.
+     * @return The optional last updated value.
+     */
+    private static Optional<NetworkTableValue> getLatestUpdate(GenericEntry entry) {
+        NetworkTableValue[] updates = entry.readQueue();
+        if (updates.length == 0) return Optional.empty();
+        return Optional.of(updates[updates.length - 1]); // TODO: make sure array is last-to-first
+    }
+}


### PR DESCRIPTION
SparkMax config IO operations like `pidController.setP()` should not be called every periodic loop, and constant reading and setting config parameters causes loop overruns. With NT3, the "correct" way to set PID gains only when shuffleboard values change would be to use callbacks, but NT4's pub-sub equivalent is `.readQueue()`.

> This uses the Set Parameter API and should be used infrequently.

Will need to be tested for performance before merge.