### PR TITLE
Use heading lock PID for regular angular input

### DIFF
--- a/src/main/java/frc/robot/commands/swerve/FollowPathCommand.java
+++ b/src/main/java/frc/robot/commands/swerve/FollowPathCommand.java
@@ -57,6 +57,9 @@ public class FollowPathCommand extends SwerveControllerCommand {
             swerveSubsystem::setSwerveModuleStates,
             swerveSubsystem
         );
+
+        // Set swerve subsystem target heading for teleop
+        swerveSubsystem.setTargetHeading(targetAngle);
     }
 
     /**


### PR DESCRIPTION
This should help eliminate "turning while translating" behavior caused by misbehaving modules.