### PR TITLE
Modular auton

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -47,7 +47,7 @@ public final class Constants {
             : -0.4294843792954861; // 2.712108274294307 flipped
         public static final double BR_OFFSET_RADS = IS_R1
             ? -2.8609512726492206 // 0.28064138094057256
-            : 1.5007363875680646; // -1.6408562660217285 flipped
+            : -0.56871098279953; // 2.572881670790263 flipped
 
         public static final int TL_DRIVE = 2;
         public static final int TL_STEER = 3;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -129,7 +129,7 @@ public final class Constants {
         public static final int EXTENSION_FOLLOW_ID = 8;
         public static final int EXTENSION_FOLLOW_B_ID = 9;
 
-        public static final float EXTENSION_LIMIT_METERS = (float) Units.inchesToMeters(64.25 + 0.75); // extra 3/4" to account for steady-state error in PID
+        public static final float EXTENSION_LIMIT_METERS = (float) Units.inchesToMeters(60.25 + 0.75); // extra 3/4" to account for steady-state error in PID
         public static final double EXTENSION_TOLERANCE_METERS = Units.inchesToMeters(1);
 
         public static final int ZERO_LIMIT_ID = 1;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -128,7 +128,7 @@ public final class Constants {
         public static final int EXTENSION_ID = 7;
         public static final int EXTENSION_FOLLOW_ID = 8;
         public static final int EXTENSION_FOLLOW_B_ID = 9;
-        
+
         public static final float EXTENSION_LIMIT_METERS = (float) Units.inchesToMeters(64.25 + 0.75); // extra 3/4" to account for steady-state error in PID
         public static final double EXTENSION_TOLERANCE_METERS = Units.inchesToMeters(1);
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -311,7 +311,7 @@ public class RobotContainer {
         if (!(driveSubsystem instanceof BaseSwerveSubsystem)) return null;
         return autonPathChooser.getSelected().apply(
             (BaseSwerveSubsystem) driveSubsystem, rollerSubsystem, tiltedElevatorSubsystem,
-            isRedEntry.getBoolean(false)
+            autonInitialPoseChooser.getSelected(), isRedEntry.getBoolean(false)
         );
     }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -116,7 +116,7 @@ public class RobotContainer {
     private final MotorTestCommand testCommand;
 
     private final BaseBalancerCommand balancerCommand;
-    private AutoAlignCommand autoAlignCommand;
+    private volatile AutoAlignCommand autoAlignCommand;
 
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -324,7 +324,7 @@ public class RobotContainer {
     public Command getAutonomousCommand() {
         // TODO: find some way to set up listeners such that we can preconstruct this before auton starts
         if (!(driveSubsystem instanceof BaseSwerveSubsystem)) return null;
-        return autonPathChooser.getSelected().apply(
+        return autonPathChooser.getSelected().create(
             (BaseSwerveSubsystem) driveSubsystem, rollerSubsystem, tiltedElevatorSubsystem,
             autonInitialPoseChooser.getSelected(), isRedEntry.getBoolean(false)
         );

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -116,7 +116,7 @@ public class RobotContainer {
     private final MotorTestCommand testCommand;
 
     private final BaseBalancerCommand balancerCommand;
-    private volatile AutoAlignCommand autoAlignCommand;
+    private final AutoAlignCommand autoAlignCommand;
 
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -158,6 +158,7 @@ public class RobotContainer {
             autoAlignCommand = new AutoAlignCommand(swerveSubsystem, tiltedElevatorSubsystem, false);
         } else {
             testCommand = null;
+            autoAlignCommand = null;
         }
 
         superstructure = new Superstructure(
@@ -180,8 +181,7 @@ public class RobotContainer {
 
         ShuffleboardUtil.addBooleanListener(isRedEntry, (isRed) -> {
             if (!(driveSubsystem instanceof BaseSwerveSubsystem)) return;
-            autoAlignCommand = new AutoAlignCommand((BaseSwerveSubsystem) driveSubsystem, tiltedElevatorSubsystem, isRed);
-            configureAutoAlignBindings();
+            autoAlignCommand.setIsRed(isRed);
 
             // TODO: preconstruct auton
         });
@@ -308,13 +308,6 @@ public class RobotContainer {
         }, signalLEDSubsystem));
 
         mechRStick.onTrue(new InstantCommand(signalLEDSubsystem::toggleManual));
-    }
-
-    private void configureAutoAlignBindings() {
-        driveController.getAlignToClosestButton().onTrue(autoAlignCommand);
-        driveController.getAlignLeftButton().onTrue(new InstantCommand(autoAlignCommand::alignLeft));
-        driveController.getAlignRightButton().onTrue(new InstantCommand(autoAlignCommand::alignRight));
-        driveController.getCancelAutoAlignButton().onTrue(new InstantCommand(autoAlignCommand::cancel));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,6 +53,7 @@ import frc.robot.subsystems.leds.LEDSubsystem;
 import frc.robot.subsystems.tiltedelevator.ElevatorState;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 import frc.robot.subsystems.tiltedelevator.ElevatorState.OffsetState;
+import frc.robot.util.ShuffleboardUtil;
 import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.drivetrain.MissileShellSwerveSubsystem;
 import frc.robot.subsystems.drivetrain.MissileShellSwerveSweeperSubsystem;
@@ -157,7 +158,6 @@ public class RobotContainer {
             autoAlignCommand = new AutoAlignCommand(swerveSubsystem, tiltedElevatorSubsystem, false);
         } else {
             testCommand = null;
-            autoAlignCommand = null;
         }
 
         superstructure = new Superstructure(
@@ -177,6 +177,14 @@ public class RobotContainer {
             .withPosition(8, 1)
             .withWidget(BuiltInWidgets.kToggleSwitch)
             .getEntry();
+
+        ShuffleboardUtil.addBooleanListener(isRedEntry, (isRed) -> {
+            if (!(driveSubsystem instanceof BaseSwerveSubsystem)) return;
+            autoAlignCommand = new AutoAlignCommand((BaseSwerveSubsystem) driveSubsystem, tiltedElevatorSubsystem, isRed);
+            configureAutoAlignBindings();
+
+            // TODO: preconstruct auton
+        });
 
         // Configure button bindings
         configureDriveBindings();
@@ -300,6 +308,13 @@ public class RobotContainer {
         }, signalLEDSubsystem));
 
         mechRStick.onTrue(new InstantCommand(signalLEDSubsystem::toggleManual));
+    }
+
+    private void configureAutoAlignBindings() {
+        driveController.getAlignToClosestButton().onTrue(autoAlignCommand);
+        driveController.getAlignLeftButton().onTrue(new InstantCommand(autoAlignCommand::alignLeft));
+        driveController.getAlignRightButton().onTrue(new InstantCommand(autoAlignCommand::alignRight));
+        driveController.getCancelAutoAlignButton().onTrue(new InstantCommand(autoAlignCommand::cancel));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -171,11 +171,11 @@ public class RobotContainer {
             .withSize(3, 1);
 
         shuffleboardTab.add("Start position", autonInitialPoseChooser)
-            .withPosition(9, 1)
+            .withPosition(0, 5)
             .withSize(2, 1);
 
         isRedEntry = shuffleboardTab.add("Is RED", false)
-            .withPosition(8, 1)
+            .withPosition(2, 5)
             .withWidget(BuiltInWidgets.kToggleSwitch)
             .getEntry();
 

--- a/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
+++ b/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
@@ -9,7 +9,7 @@ import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 @FunctionalInterface
 public interface AutonFactoryFunction {
-    Command apply(
+    Command create(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
         PlacePosition initialPosition, boolean isRed
     );

--- a/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
+++ b/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
@@ -1,0 +1,15 @@
+package frc.robot.commands.auton;
+
+import edu.wpi.first.wpilibj2.command.Command;
+
+import frc.robot.subsystems.RollerSubsystem;
+import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
+import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
+
+@FunctionalInterface
+public interface AutonFactoryFunction {
+    Command apply(
+        BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
+        boolean isRed
+    );
+}

--- a/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
+++ b/src/main/java/frc/robot/commands/auton/AutonFactoryFunction.java
@@ -2,6 +2,7 @@ package frc.robot.commands.auton;
 
 import edu.wpi.first.wpilibj2.command.Command;
 
+import frc.robot.positions.PlacePosition;
 import frc.robot.subsystems.RollerSubsystem;
 import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
@@ -10,6 +11,6 @@ import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 public interface AutonFactoryFunction {
     Command apply(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed
+        PlacePosition initialPosition, boolean isRed
     );
 }

--- a/src/main/java/frc/robot/commands/auton/BalanceAndTaxiAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/BalanceAndTaxiAutonSequence.java
@@ -11,20 +11,19 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class BalanceAndTaxiAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.B2_HIGH;
-
     /**
      * Balancing auton sequence with mobility bonus.
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public BalanceAndTaxiAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
         addCommands(
             // Go over the charging station to taxi
@@ -39,15 +38,16 @@ public class BalanceAndTaxiAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      * @return The created auton path.
      */
     public static ParallelDeadlineGroup withDeadline(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
         return new WaitCommand(14.5).deadlineWith(
-            new BalanceAndTaxiAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, isRed)
+            new BalanceAndTaxiAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed)
         );
     }
 }

--- a/src/main/java/frc/robot/commands/auton/BalanceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/BalanceAutonSequence.java
@@ -10,20 +10,19 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class BalanceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.B2_HIGH;
-
     /**
      * Balancing auton sequence.
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public BalanceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
         addCommands(
             // Go and balance on charging station
@@ -36,15 +35,16 @@ public class BalanceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      * @return The created auton path.
      */
     public static ParallelDeadlineGroup withDeadline(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
         return new WaitCommand(14.5).deadlineWith(
-            new BalanceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, isRed)
+            new BalanceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed)
         );
     }
 }

--- a/src/main/java/frc/robot/commands/auton/BottomBalanceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/BottomBalanceAutonSequence.java
@@ -15,8 +15,6 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class BottomBalanceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.A2_HIGH;
-
     private static final FieldPosition MID_POSE_1 = FieldPosition.BOTTOM_MIDPOS_1;
     private static final FieldPosition MID_POSE_2 = FieldPosition.BOTTOM_MIDPOS_2;
     private static final FieldPosition MID_POSE_3 = FieldPosition.BOTTOM_1PIECEPOS;
@@ -27,15 +25,16 @@ public class BottomBalanceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public BottomBalanceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
-        Pose2d initialPose = INITIAL_POSE.alignPosition.getPose(isRed);
+        Pose2d initialPose = initialPosition.alignPosition.getPose(isRed);
         Pose2d midPose1 = MID_POSE_1.getPose(isRed);
         Pose2d midPose2 = MID_POSE_2.getPose(isRed);
         Pose2d midPose3 = MID_POSE_3.getPose(isRed);
@@ -59,15 +58,16 @@ public class BottomBalanceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      * @return The created auton path.
      */
     public static ParallelDeadlineGroup withDeadline(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
         return new WaitCommand(14.5).deadlineWith(
-            new BottomBalanceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, isRed)
+            new BottomBalanceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed)
         );
     }
 }

--- a/src/main/java/frc/robot/commands/auton/BottomOnePieceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/BottomOnePieceAutonSequence.java
@@ -12,8 +12,6 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class BottomOnePieceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.A2_HIGH;
-
     private static final FieldPosition MID_POSE_1 = FieldPosition.BOTTOM_MIDPOS_1;
     private static final FieldPosition MID_POSE_2 = FieldPosition.BOTTOM_MIDPOS_2;
     private static final FieldPosition FINAL_POSE = FieldPosition.BOTTOM_1PIECEPOS;
@@ -23,15 +21,16 @@ public class BottomOnePieceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public BottomOnePieceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
-        Pose2d initialPose = INITIAL_POSE.alignPosition.getPose(isRed);
+        Pose2d initialPose = initialPosition.alignPosition.getPose(isRed);
         Pose2d midPose1 = MID_POSE_1.getPose(isRed);
         Pose2d midPose2 = MID_POSE_2.getPose(isRed);
         Pose2d finalPose = FINAL_POSE.getPose(isRed);

--- a/src/main/java/frc/robot/commands/auton/BottomTwoPieceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/BottomTwoPieceAutonSequence.java
@@ -13,8 +13,6 @@ import frc.robot.subsystems.tiltedelevator.ElevatorState;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class BottomTwoPieceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.A2_HIGH;
-
     private static final FieldPosition MID_POSE_1 = FieldPosition.BOTTOM_MIDPOS_1;
     private static final FieldPosition MID_POSE_2 = FieldPosition.BOTTOM_MIDPOS_2;
 
@@ -26,15 +24,16 @@ public class BottomTwoPieceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public BottomTwoPieceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
-        Pose2d initialPose = INITIAL_POSE.alignPosition.getPose(isRed);
+        Pose2d initialPose = initialPosition.alignPosition.getPose(isRed);
         Pose2d midPose1 = MID_POSE_1.getPose(isRed);
         Pose2d midPose2 = MID_POSE_2.getPose(isRed);
 

--- a/src/main/java/frc/robot/commands/auton/PreloadedOnlyAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/PreloadedOnlyAutonSequence.java
@@ -6,8 +6,6 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class PreloadedOnlyAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.A2_HIGH;
-
     /**
      * Preloaded-only auton sequence. This only places the preloaded game piece and
      * does not taxi.
@@ -15,12 +13,13 @@ public class PreloadedOnlyAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
      * @param isRed Whether this is a red auton path.
      */
     public PreloadedOnlyAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
     }
 }

--- a/src/main/java/frc/robot/commands/auton/TopOnePieceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/TopOnePieceAutonSequence.java
@@ -12,8 +12,6 @@ import frc.robot.subsystems.drivetrain.BaseSwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class TopOnePieceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.C2_HIGH;
-
     private static final FieldPosition MID_POSE_1 = FieldPosition.TOP_MIDPOS_1;
     private static final FieldPosition MID_POSE_2 = FieldPosition.TOP_MIDPOS_2;
 
@@ -22,14 +20,16 @@ public class TopOnePieceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
+     * @param isRed Whether this is a red auton path.
      */
     public TopOnePieceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
-        Pose2d initialPose = INITIAL_POSE.alignPosition.getPose(isRed);
+        Pose2d initialPose = initialPosition.alignPosition.getPose(isRed);
         Pose2d midPose1 = MID_POSE_1.getPose(isRed);
         Pose2d midPose2 = MID_POSE_2.getPose(isRed);
 

--- a/src/main/java/frc/robot/commands/auton/TopTwoPieceAutonSequence.java
+++ b/src/main/java/frc/robot/commands/auton/TopTwoPieceAutonSequence.java
@@ -12,8 +12,6 @@ import frc.robot.subsystems.tiltedelevator.ElevatorState;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
 public class TopTwoPieceAutonSequence extends BaseAutonSequence {
-    private static final PlacePosition INITIAL_POSE = PlacePosition.C2_HIGH;
-
     private static final FieldPosition MID_POSE_1 = FieldPosition.TOP_MIDPOS_1;
     private static final FieldPosition MID_POSE_2 = FieldPosition.TOP_MIDPOS_2;
     private static final FieldPosition MID_POSE_3 = FieldPosition.TOP_MIDPOS_3;
@@ -27,14 +25,16 @@ public class TopTwoPieceAutonSequence extends BaseAutonSequence {
      * @param swerveSubsystem The swerve subsystem.
      * @param rollerSubsystem The roller subsystem.
      * @param tiltedElevatorSubsystem The tilted elevator subsystem.
+     * @param initialPosition The initial place position of the sequence.
+     * @param isRed Whether this is a red auton path.
      */
     public TopTwoPieceAutonSequence(
         BaseSwerveSubsystem swerveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem,
-        boolean isRed // TODO: better way of passing this
+        PlacePosition initialPosition, boolean isRed // TODO: better way of passing this
     ) {
-        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, INITIAL_POSE, isRed);
+        super(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, initialPosition, isRed);
 
-        Pose2d initialPose = INITIAL_POSE.alignPosition.getPose(isRed);
+        Pose2d initialPose = initialPosition.alignPosition.getPose(isRed);
         Pose2d midPose1 = MID_POSE_1.getPose(isRed);
         Pose2d midPose2 = MID_POSE_2.getPose(isRed);
         Pose2d midPose3 = MID_POSE_3.getPose(isRed);

--- a/src/main/java/frc/robot/commands/dropping/AutoAlignCommand.java
+++ b/src/main/java/frc/robot/commands/dropping/AutoAlignCommand.java
@@ -30,7 +30,7 @@ import frc.robot.subsystems.tiltedelevator.ElevatorState.OffsetState;
 public class AutoAlignCommand extends InstantCommand {
     private final BaseSwerveSubsystem swerveSubsystem;
     private final TiltedElevatorSubsystem tiltedElevatorSubsystem;
-    private final boolean isRed;
+    private boolean isRed;
 
     private final InstantCommand[] setTargetCommands;
     private final HashMap<FieldPosition, GenericEntry> booleanEntries;
@@ -305,6 +305,14 @@ public class AutoAlignCommand extends InstantCommand {
         // Revert strafing lock and target place position
         swerveSubsystem.setChargingStationLocked(false);
         targetPlacePosition = null;
+    }
+
+    /**
+     * Sets the alliance of this auto align command.
+     * @param isRed Whether the robot is on the red team. If false, aligns to blue nodes.
+     */
+    public void setIsRed(boolean isRed) {
+        this.isRed = isRed;
     }
 
     private static int getShuffleboardRow(PlacePosition position) {

--- a/src/main/java/frc/robot/subsystems/RollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RollerSubsystem.java
@@ -68,8 +68,8 @@ public class RollerSubsystem extends SubsystemBase {
 
     public RollerSubsystem() {
         leftBeak = MotorUtil.createTalonSRX(LEFT_ID);
-        leftBeak.setInverted(true);
-        // leftBeak.setInverted(false);
+        // leftBeak.setInverted(true);
+        leftBeak.setInverted(false);
         leftBeak.setNeutralMode(NeutralMode.Brake);
 
         rightBeak = MotorUtil.createTalonSRX(RIGHT_ID);

--- a/src/main/java/frc/robot/subsystems/RollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RollerSubsystem.java
@@ -194,7 +194,7 @@ public class RollerSubsystem extends SubsystemBase {
         // Otherwise, open if we're opening and close if we're closing.
         if (openTimer.hasStarted()) openMotor.set(0.5);
         else if (closeTimer.hasStarted()) openMotor.set(-0.2);
-        else if (heldPiece == HeldPiece.CONE) openMotor.set(-0.14);
+        else if (heldPiece == HeldPiece.CONE) openMotor.setVoltage(-4.0);
         else openMotor.set(0);
     }
 

--- a/src/main/java/frc/robot/subsystems/Superstructure.java
+++ b/src/main/java/frc/robot/subsystems/Superstructure.java
@@ -21,6 +21,8 @@ public class Superstructure extends SubsystemBase {
     private final SwitchableCamera switchableCamera;
     private final BaseDriveController driveController;
 
+    private static final double CANCEL_AUTO_ALIGN_POWER = 0.1;
+
     private ElevatorState lastElevatorState;
 
     public Superstructure(
@@ -61,10 +63,11 @@ public class Superstructure extends SubsystemBase {
         rollerSubsystem.allowOpen = tiltedElevatorSubsystem.getExtensionMeters() >= ALLOW_OPEN_EXTENSION_METERS;
 
         // Cancel auto-align command if magnitude of drive inputs is greater than 0.15.
-        double inputMagnitude = Math.hypot(
+        double translateMagnitude = Math.hypot(
             driveController.getForwardPower(),
             driveController.getLeftPower()
         );
-        if (inputMagnitude > 0.15) autoAlignCommand.cancel();
+        double turnMagnitude = Math.abs(driveController.getRotatePower());
+        if (translateMagnitude > CANCEL_AUTO_ALIGN_POWER || turnMagnitude > CANCEL_AUTO_ALIGN_POWER) autoAlignCommand.cancel();
     }
 }

--- a/src/main/java/frc/robot/vision/SwitchableCamera.java
+++ b/src/main/java/frc/robot/vision/SwitchableCamera.java
@@ -49,6 +49,7 @@ public class SwitchableCamera {
         // back.getProperty("raw_brightness").set(40);
 
         server = CameraServer.getServer();
+        server.setSource(bottom);
 
         widget = shuffleboardTab.add("Intake Camera", getSource())
             .withPosition(9, 0)
@@ -69,8 +70,8 @@ public class SwitchableCamera {
      */
     public void setCamera(boolean useTop) {
         this.topActive = useTop;
-        server.setSource(this.topActive ? top : bottom);
-        widget.withProperties(Map.of("Rotation", this.topActive ? "NONE" : "QUARTER_CW"));
+        // server.setSource(this.topActive ? top : bottom);
+        // widget.withProperties(Map.of("Rotation", this.topActive ? "NONE" : "QUARTER_CW"));
     }
 
     /**

--- a/src/test/java/AutonPathTest.java
+++ b/src/test/java/AutonPathTest.java
@@ -15,6 +15,7 @@ import frc.robot.commands.auton.test.HighRotationLinePath;
 import frc.robot.commands.auton.test.RotatingSCurveAutonSequence;
 import frc.robot.commands.auton.test.TenFeetStraightLinePath;
 import frc.robot.commands.auton.test.TwentyFeetStraightLinePath;
+import frc.robot.positions.PlacePosition;
 import frc.robot.subsystems.RollerSubsystem;
 import frc.robot.subsystems.drivetrain.SwerveSubsystem;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
@@ -43,14 +44,14 @@ public class AutonPathTest {
      */
     @Test
     public void compileRedPaths() {
-        new PreloadedOnlyAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        new TopOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        new TopTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        BalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        BalanceAndTaxiAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        new BottomOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        new BottomTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
-        BottomBalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, true);
+        new PreloadedOnlyAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, true);
+        new TopOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.C2_HIGH, true);
+        new TopTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.C2_HIGH, true);
+        BalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.B2_HIGH, true);
+        BalanceAndTaxiAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.B2_HIGH, true);
+        new BottomOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, true);
+        new BottomTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, true);
+        BottomBalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, true);
     }
 
     /**
@@ -58,13 +59,13 @@ public class AutonPathTest {
      */
     @Test
     public void compileBluePaths() {
-        new PreloadedOnlyAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        new TopOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        new TopTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        BalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        BalanceAndTaxiAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        new BottomOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        new BottomTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
-        BottomBalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, false);
+        new PreloadedOnlyAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, false);
+        new TopOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.C2_HIGH, false);
+        new TopTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.C2_HIGH, false);
+        BalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.B2_HIGH, false);
+        BalanceAndTaxiAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.B2_HIGH, false);
+        new BottomOnePieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, false);
+        new BottomTwoPieceAutonSequence(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, false);
+        BottomBalanceAutonSequence.withDeadline(swerveSubsystem, rollerSubsystem, tiltedElevatorSubsystem, PlacePosition.A2_HIGH, false);
     }
 }


### PR DESCRIPTION
@CrolineCrois 

The idea with this setup is that `RobotContainer` uses shuffleboard choosers to select initial position, `isRed`, etc., and every time a value changes the robot would reconstruct the autonomous command (and auto-align when the team color changes) accordingly. We seemingly can't set up listeners on shuffleboard choosers though, so something else needs to be figured out for that.

Some TODOs from the current setup:
- Auton sequence is constructed at the start of auton in `.getAutonomousCommand()` instead of preconstructed before auton begins
- ~~Test if reconstructing `AutoAlignCommand` and rebinding the buttons successfully removes the old bindings~~