### PR TITLE
Drive forward button for auto align

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -215,10 +215,8 @@ public class RobotContainer {
             driveController.getAlignToClosestButton().onTrue(autoAlignCommand);
             driveController.getAlignLeftButton().onTrue(new InstantCommand(autoAlignCommand::alignLeft));
             driveController.getAlignRightButton().onTrue(new InstantCommand(autoAlignCommand::alignRight));
+            driveController.getDriveForwardButton().onTrue(new InstantCommand(autoAlignCommand::driveForwardToPlace));
             driveController.getCancelAutoAlignButton().onTrue(new InstantCommand(autoAlignCommand::cancel));
-
-            // TODO: drive bindings
-            mechLStick.onTrue(new InstantCommand(autoAlignCommand::driveForwardToPlace));
 
             /*
             brSwitch.onTrue(new InstantCommand(() -> {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -217,6 +217,9 @@ public class RobotContainer {
             driveController.getAlignRightButton().onTrue(new InstantCommand(autoAlignCommand::alignRight));
             driveController.getCancelAutoAlignButton().onTrue(new InstantCommand(autoAlignCommand::cancel));
 
+            // TODO: drive bindings
+            mechLStick.onTrue(new InstantCommand(autoAlignCommand::driveForwardToPlace));
+
             /*
             brSwitch.onTrue(new InstantCommand(() -> {
                 swerveSubsystem.setSteerRelativeEncoderFeedback(true);

--- a/src/main/java/frc/robot/commands/dropping/DropperChooserCommand.java
+++ b/src/main/java/frc/robot/commands/dropping/DropperChooserCommand.java
@@ -62,10 +62,9 @@ public class DropperChooserCommand extends InstantCommand {
                 0, 0.2, 0.5, 0.2, 0.5
             );
 
-            // TODO: tune
             case GROUND -> new DropSequence(
                 driveSubsystem, rollerSubsystem, tiltedElevatorSubsystem,
-                0, 0.2, 0.5, 0.2, 0.5
+                0, 0.65, 0.5, 0.2, 0.5
             );
 
             default -> new DropSequence(

--- a/src/main/java/frc/robot/controllers/BaseDriveController.java
+++ b/src/main/java/frc/robot/controllers/BaseDriveController.java
@@ -41,5 +41,6 @@ public abstract class BaseDriveController {
     public abstract JoystickButton getAlignToClosestButton();
     public abstract JoystickButton getAlignLeftButton();
     public abstract JoystickButton getAlignRightButton();
+    public abstract JoystickButton getDriveForwardButton();
     public abstract JoystickButton getCancelAutoAlignButton();
 }

--- a/src/main/java/frc/robot/controllers/DualJoystickDriveController.java
+++ b/src/main/java/frc/robot/controllers/DualJoystickDriveController.java
@@ -93,6 +93,11 @@ public class DualJoystickDriveController extends BaseDriveController {
     }
 
     @Override
+    public JoystickButton getDriveForwardButton() {
+        return rightTopLeftButton;
+    }
+
+    @Override
     public JoystickButton getCancelAutoAlignButton() {
         return rightBackButton;
     }

--- a/src/main/java/frc/robot/controllers/TwistJoystickDriveController.java
+++ b/src/main/java/frc/robot/controllers/TwistJoystickDriveController.java
@@ -84,6 +84,12 @@ public class TwistJoystickDriveController extends BaseDriveController {
     }
 
     @Override
+    public JoystickButton getDriveForwardButton() {
+        // TODO: this button is double bound, but there aren't enough buttons left for these controls
+        return leftTopLeftButton;
+    }
+
+    @Override
     public JoystickButton getCancelAutoAlignButton() {
         return leftMiddleButton;
     }

--- a/src/main/java/frc/robot/controllers/XboxDriveController.java
+++ b/src/main/java/frc/robot/controllers/XboxDriveController.java
@@ -16,7 +16,9 @@ public class XboxDriveController extends BaseDriveController {
         driveLBumper = new JoystickButton(driveController, XboxController.Button.kLeftBumper.value),
         driveRBumper = new JoystickButton(driveController, XboxController.Button.kRightBumper.value),
         driveLStickButton = new JoystickButton(driveController, XboxController.Button.kLeftStick.value),
-        driveRStickButton = new JoystickButton(driveController, XboxController.Button.kRightStick.value);
+        driveRStickButton = new JoystickButton(driveController, XboxController.Button.kRightStick.value),
+        driveBackButton = new JoystickButton(driveController, XboxController.Button.kBack.value),
+        driveStartButton = new JoystickButton(driveController, XboxController.Button.kStart.value);
 
     @Override
     public double getForwardPower() {
@@ -76,6 +78,11 @@ public class XboxDriveController extends BaseDriveController {
     @Override
     public JoystickButton getAlignRightButton() {
         return driveRBumper;
+    }
+
+    @Override
+    public JoystickButton getDriveForwardButton() {
+        return driveStartButton;
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/RollerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RollerSubsystem.java
@@ -79,7 +79,8 @@ public class RollerSubsystem extends SubsystemBase {
 
         openMotor = MotorUtil.createTalonSRX(OPEN_ID);
         openMotor.setNeutralMode(NeutralMode.Brake);
-        openMotor.setInverted(true);
+        // openMotor.setInverted(true);
+        openMotor.setInverted(false);
 
         limitSwitch = new DigitalInput(LIMIT_SWITCH_ID);
         crolorSensor = new ColorSensorV3(I2C.Port.kMXP);

--- a/src/main/java/frc/robot/subsystems/tiltedelevator/ElevatorState.java
+++ b/src/main/java/frc/robot/subsystems/tiltedelevator/ElevatorState.java
@@ -5,7 +5,7 @@ import edu.wpi.first.math.util.Units;
 import frc.robot.Constants;
 
 public enum ElevatorState {
-    GROUND(0, Units.inchesToMeters(6), 0),
+    GROUND(0, Units.inchesToMeters(6), Units.inchesToMeters(6)),
     CHUTE(Units.inchesToMeters(40)),
     SUBSTATION(Units.inchesToMeters(45)), // absolute height = 37.375 in
     CUBE_MID(Units.inchesToMeters(Constants.IS_R1 ? 33 : 40)), // absolute height = 14.25 in


### PR DESCRIPTION
This is a less complete abstraction than #102 that keeps separate the "drive forward" and "dropping" components of scoring after a successful auto-align.

Also some slight changes to hybrid node drop sequences, but still needs to be tested on a repaired elevator / intake.