### PR TITLE
Use proxy command for dropper chooser

### DIFF
--- a/src/main/java/frc/robot/commands/dropping/DropperChooserCommand.java
+++ b/src/main/java/frc/robot/commands/dropping/DropperChooserCommand.java
@@ -1,6 +1,6 @@
 package frc.robot.commands.dropping;
 
-import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ProxyCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import frc.robot.subsystems.RollerSubsystem;
@@ -8,13 +8,11 @@ import frc.robot.subsystems.drivetrain.BaseDrivetrain;
 import frc.robot.subsystems.tiltedelevator.ElevatorState;
 import frc.robot.subsystems.tiltedelevator.TiltedElevatorSubsystem;
 
-public class DropperChooserCommand extends InstantCommand {
+public class DropperChooserCommand extends ProxyCommand {
     public DropperChooserCommand(
         BaseDrivetrain driveSubsystem, RollerSubsystem rollerSubsystem, TiltedElevatorSubsystem tiltedElevatorSubsystem
     ) {
-        super(() -> {
-            getSequence(driveSubsystem, rollerSubsystem, tiltedElevatorSubsystem).schedule();
-        }, rollerSubsystem, tiltedElevatorSubsystem, driveSubsystem);
+        super(() -> getSequence(driveSubsystem, rollerSubsystem, tiltedElevatorSubsystem));
     }
 
     /**


### PR DESCRIPTION
Also perhaps will use a proxy command for auto align too to make things more clean? I thought this might help with greg's buttons too but that doesn't quite make sense because a command with shared dependencies should cancel all other commands with those dependencies when it is scheduled, so even if the command being put on shuffleboard has finished due to being an `InstantCommand` the wrapped command it scheduled should get cancelled by the next button's instant command.