### PR TITLE
Fix theoretical bug with repeated aligning to same pose

### DIFF
--- a/src/main/java/frc/robot/commands/swerve/GoToPointCommand.java
+++ b/src/main/java/frc/robot/commands/swerve/GoToPointCommand.java
@@ -92,4 +92,9 @@ public class GoToPointCommand extends CommandBase {
         double yErrorMeters = Math.abs(targetPose.getY() - currentPose.getY());
         return xErrorMeters < X_TOLERANCE_METERS && yErrorMeters < Y_TOLERANCE_METERS && isHeadingAligned(THETA_TOLERANCE_RADS);
     }
+
+    @Override
+    public void end(boolean interrupted) {
+        currentPose = null;
+    }
 }


### PR DESCRIPTION
If `currentPose` is queried by the `WaitUntilCommand` before a first call of `GoToPointCommand.execute()` (which it did at Paly, as seen by the `NullPointerException`), the old `currentPose` from the last run of the command will be stored and `isHeadingAligned` will immediately return true.

Therefore, theoretically aligning to the same point twice will cause the elevator to lift immediately without this behavior.